### PR TITLE
Allow query bind

### DIFF
--- a/src/Backend/Snowflake/Exporter.php
+++ b/src/Backend/Snowflake/Exporter.php
@@ -38,6 +38,6 @@ class Exporter implements ExporterInterface
         }
         $adapter = $destination->getBackendExportAdapter($this);
         $cmd = $adapter->getCopyCommand($source, $options);
-        $this->connection->fetchAll($cmd);
+        $this->connection->fetchAll($cmd, $options->getQueryBindings());
     }
 }

--- a/src/ExportOptions.php
+++ b/src/ExportOptions.php
@@ -16,17 +16,29 @@ class ExportOptions
      */
     private $isCompresed;
 
+    /**
+     * @var array
+     */
+    private $queryBinding;
+
     public function __construct(
         ?string $query = null,
+        array $queryBindings = [],
         bool $isCompresed = false
     ) {
         $this->query = $query;
         $this->isCompresed = $isCompresed;
+        $this->queryBinding = $queryBindings;
     }
 
     public function getQuery(): ?string
     {
         return $this->query;
+    }
+
+    public function getQueryBindings(): array
+    {
+        return $this->queryBinding;
     }
 
     public function isCompresed(): bool

--- a/tests/functional/Snowflake/ExportTest.php
+++ b/tests/functional/Snowflake/ExportTest.php
@@ -64,7 +64,7 @@ class ExportTest extends SnowflakeImportExportBaseTest
 
         // export
         $source = $destination;
-        $options = new ExportOptions(null, true);
+        $options = new ExportOptions(null, [], true);
         $destination = $this->createABSSourceDestinationInstance(self::EXPORT_BLOB_DIR . '/gz_test');
 
         (new Exporter($this->connection))->exportTable(

--- a/tests/unit/SourceStorage/ABS/SnowflakeExportAdapterTest.php
+++ b/tests/unit/SourceStorage/ABS/SnowflakeExportAdapterTest.php
@@ -53,7 +53,7 @@ EOT
         $destination->expects(self::once())->method('getSasToken')->willReturn('sasToken');
 
         $source = new Storage\Snowflake\Table('schema', 'table');
-        $options = new ExportOptions(null, true);
+        $options = new ExportOptions(null, [], true);
         $adapter = new Storage\ABS\SnowflakeExportAdapter($destination);
         $commands = $adapter->getCopyCommand(
             $source,


### PR DESCRIPTION
`ExportOptions` can specify SQL query which will be used to query data from table to file storage.

This PR adds new option `queryBindings` which can specify query parameters.

Original usage of parameters in KBC
https://github.com/keboola/connection/blob/d5f505ff84f40a0d3a40c353218033356459a136/legacy-app/application/modules/storage/services/BucketBackend/Snowflake.php#L462-L476

Now handled by lib here:
https://github.com/keboola/connection/blob/d5f505ff84f40a0d3a40c353218033356459a136/legacy-app/application/modules/storage/services/BucketBackend/Snowflake.php#L446

