### PR TITLE
KBC-168 new import adapters

### DIFF
--- a/src/Backend/BackendImportAdapterInterface.php
+++ b/src/Backend/BackendImportAdapterInterface.php
@@ -4,20 +4,23 @@ declare(strict_types=1);
 
 namespace Keboola\Db\ImportExport\Backend;
 
-use Keboola\Db\Import\Snowflake\Connection;
 use Keboola\Db\ImportExport\ImportOptions;
-use Keboola\Db\ImportExport\Storage\DestinationInterface;
+use Keboola\Db\ImportExport\Storage;
 
 interface BackendImportAdapterInterface
 {
+    public static function isSupported(
+        Storage\SourceInterface $source,
+        Storage\DestinationInterface $destination
+    ): bool;
+
     /**
-     * @param null|Connection|\Doctrine\DBAL\Connection $connection
      * @return string[]
      */
     public function getCopyCommands(
-        DestinationInterface $destination,
+        Storage\SourceInterface $source,
+        Storage\DestinationInterface $destination,
         ImportOptions $importOptions,
-        string $stagingTableName,
-        $connection = null
+        string $stagingTableName
     ): array;
 }

--- a/src/Backend/ImporterInterface.php
+++ b/src/Backend/ImporterInterface.php
@@ -17,4 +17,6 @@ interface ImporterInterface
         Storage\DestinationInterface $destination,
         ImportOptions $options
     ): Result;
+
+    public function setAdapters(array $adapters): void;
 }

--- a/src/Backend/Snowflake/Importer.php
+++ b/src/Backend/Snowflake/Importer.php
@@ -25,9 +25,6 @@ class Importer implements ImporterInterface
     /** @var string[] */
     private $adapters = self::DEFAULT_ADAPTERS;
 
-    /** @var SnowflakeImportAdapterInterface */
-    private $currentImportAdapter;
-
     /** @var Connection */
     private $connection;
 
@@ -56,7 +53,7 @@ class Importer implements ImporterInterface
         Storage\DestinationInterface $destination,
         ImportOptions $options
     ): Result {
-        $this->setUpAdapter($source, $destination);
+        $adapter = $this->getAdapter($source, $destination);
 
         $this->importState = new ImportState(BackendHelper::generateStagingTableName());
         $this->validateColumns($options, $destination);
@@ -69,7 +66,12 @@ class Importer implements ImporterInterface
 
         try {
             //import files to staging table
-            $this->importToStagingTable($source, $destination, $options);
+            $this->importToStagingTable(
+                $source,
+                $destination,
+                $options,
+                $adapter
+            );
             $primaryKeys = $this->connection->getTablePrimaryKey(
                 $destination->getSchema(),
                 $destination->getTableName()
@@ -133,9 +135,10 @@ class Importer implements ImporterInterface
     private function importToStagingTable(
         Storage\SourceInterface $source,
         Storage\DestinationInterface $destination,
-        ImportOptions $importOptions
+        ImportOptions $importOptions,
+        SnowflakeImportAdapterInterface $adapter
     ): void {
-        $commands = $this->currentImportAdapter->getCopyCommands(
+        $commands = $adapter->getCopyCommands(
             $source,
             $destination,
             $importOptions,
@@ -283,9 +286,11 @@ class Importer implements ImporterInterface
         $this->adapters = $adapters;
     }
 
-    private function setUpAdapter(Storage\SourceInterface $source, Storage\DestinationInterface $destination): void
-    {
-        $adapterFound = false;
+    private function getAdapter(
+        Storage\SourceInterface $source,
+        Storage\DestinationInterface $destination
+    ): SnowflakeImportAdapterInterface {
+        $adapterForUse = null;
         foreach ($this->adapters as $adapter) {
             $ref = new \ReflectionClass($adapter);
             if (!$ref->implementsInterface(SnowflakeImportAdapterInterface::class)) {
@@ -297,21 +302,20 @@ class Importer implements ImporterInterface
                 );
             }
             if ($adapter::isSupported($source, $destination)) {
-                if ($adapterFound === true) {
+                if ($adapterForUse !== null) {
                     throw new \Exception(
                         sprintf(
                             'More than one suitable adapter found for Snowflake importer with source: '
-                            .'"%s", destination "%s".',
+                            . '"%s", destination "%s".',
                             get_class($source),
                             get_class($destination)
                         )
                     );
                 }
-                $this->currentImportAdapter = new $adapter($this->connection);
-                $adapterFound = true;
+                $adapterForUse = new $adapter($this->connection);
             }
         }
-        if ($adapterFound === false) {
+        if ($adapterForUse === null) {
             throw new \Exception(
                 sprintf(
                     'No suitable adapter found for Snowflake importer with source: "%s", destination "%s".',
@@ -320,5 +324,7 @@ class Importer implements ImporterInterface
                 )
             );
         }
+
+        return $adapterForUse;
     }
 }

--- a/src/Backend/Snowflake/SnowflakeImportAdapterInterface.php
+++ b/src/Backend/Snowflake/SnowflakeImportAdapterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Db\ImportExport\Backend\Snowflake;
+
+use Keboola\Db\Import\Snowflake\Connection;
+use Keboola\Db\ImportExport\Backend\BackendImportAdapterInterface;
+
+interface SnowflakeImportAdapterInterface extends BackendImportAdapterInterface
+{
+    public function __construct(Connection $connection);
+}

--- a/src/Backend/Synapse/SynapseImportAdapterInterface.php
+++ b/src/Backend/Synapse/SynapseImportAdapterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Db\ImportExport\Backend\Synapse;
+
+use Doctrine\DBAL\Connection;
+use Keboola\Db\ImportExport\Backend\BackendImportAdapterInterface;
+
+interface SynapseImportAdapterInterface extends BackendImportAdapterInterface
+{
+    public function __construct(Connection $connection);
+}

--- a/src/Storage/ABS/BaseFile.php
+++ b/src/Storage/ABS/BaseFile.php
@@ -50,7 +50,7 @@ abstract class BaseFile
      * Snowflake won't import files if protocol is other than azure://
      * Synapse won't import files if protocol is other than https://
      */
-    public function getContainerUrl(string $protocol = self::PROTOCOL_AZURE): string
+    public function getContainerUrl(string $protocol): string
     {
         return sprintf(
             '%s://%s.blob.core.windows.net/%s/',

--- a/src/Storage/ABS/SnowflakeExportAdapter.php
+++ b/src/Storage/ABS/SnowflakeExportAdapter.php
@@ -56,7 +56,7 @@ FILE_FORMAT = (
     TIMESTAMP_FORMAT = \'YYYY-MM-DD HH24:MI:SS\'
 )
 MAX_FILE_SIZE=50000000',
-            $this->destination->getContainerUrl(),
+            $this->destination->getContainerUrl(BaseFile::PROTOCOL_AZURE),
             $this->destination->getFilePath(),
             $from,
             $this->destination->getSasToken(),

--- a/src/Storage/ABS/SourceFile.php
+++ b/src/Storage/ABS/SourceFile.php
@@ -41,19 +41,6 @@ class SourceFile extends BaseFile implements SourceInterface
         $this->csvOptions = $csvOptions;
     }
 
-    public function getBackendImportAdapter(
-        ImporterInterface $importer
-    ): BackendImportAdapterInterface {
-        switch (true) {
-            case $importer instanceof SnowflakeImporter:
-                return new SnowflakeImportAdapter($this);
-            case $importer instanceof SynapseImporter:
-                return new SynapseImportAdapter($this);
-            default:
-                throw new NoBackendAdapterException();
-        }
-    }
-
     public function getCsvOptions(): CsvOptions
     {
         return $this->csvOptions;

--- a/src/Storage/Snowflake/SelectSource.php
+++ b/src/Storage/Snowflake/SelectSource.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\Db\ImportExport\Storage\Snowflake;
 
-use Keboola\Db\ImportExport\Backend\BackendImportAdapterInterface;
-use Keboola\Db\ImportExport\Backend\ImporterInterface;
-use Keboola\Db\ImportExport\Storage\NoBackendAdapterException;
 use Keboola\Db\ImportExport\Storage\SourceInterface;
 use Keboola\Db\ImportExport\Storage\SqlSourceInterface;
 
@@ -26,12 +23,6 @@ class SelectSource implements SourceInterface, SqlSourceInterface
     {
         $this->query = $query;
         $this->queryBindings = $queryBindings;
-    }
-
-    public function getBackendImportAdapter(
-        ImporterInterface $importer
-    ): BackendImportAdapterInterface {
-        throw new NoBackendAdapterException();
     }
 
     public function getFromStatement(): string

--- a/src/Storage/Snowflake/SnowflakeImportAdapter.php
+++ b/src/Storage/Snowflake/SnowflakeImportAdapter.php
@@ -4,53 +4,58 @@ declare(strict_types=1);
 
 namespace Keboola\Db\ImportExport\Storage\Snowflake;
 
-use Keboola\Db\ImportExport\Backend\BackendImportAdapterInterface;
+use Keboola\Db\Import\Snowflake\Connection;
+use Keboola\Db\ImportExport\Backend\Snowflake\SnowflakeImportAdapterInterface;
 use Keboola\Db\ImportExport\ImportOptions;
-use Keboola\Db\ImportExport\Backend\Snowflake\Helper\QuoteHelper;
-use Keboola\Db\ImportExport\Storage\DestinationInterface;
-use Keboola\Db\ImportExport\Storage\SourceInterface;
+use Keboola\Db\ImportExport\Storage;
 
-class SnowflakeImportAdapter implements BackendImportAdapterInterface
+class SnowflakeImportAdapter implements SnowflakeImportAdapterInterface
 {
-    /**
-     * @var Table
-     */
-    private $source;
+    /** @var Connection */
+    private $connection;
 
-    /**
-     * @param Table $source
-     */
-    public function __construct(SourceInterface $source)
+    public function __construct(Connection $connection)
     {
-        $this->source = $source;
+        $this->connection = $connection;
+    }
+
+    public static function isSupported(Storage\SourceInterface $source, Storage\DestinationInterface $destination): bool
+    {
+        if (!$source instanceof Storage\Snowflake\Table) {
+            return false;
+        }
+        if (!$destination instanceof Storage\Snowflake\Table) {
+            return false;
+        }
+        return true;
     }
 
     /**
-     * @param Table $destination
-     * @param null $connection
+     * @param Storage\Snowflake\Table $source
+     * @param Storage\Snowflake\Table $destination
      */
     public function getCopyCommands(
-        DestinationInterface $destination,
+        Storage\SourceInterface $source,
+        Storage\DestinationInterface $destination,
         ImportOptions $importOptions,
-        string $stagingTableName,
-        $connection = null
+        string $stagingTableName
     ): array {
         $quotedColumns = array_map(function ($column) {
-            return QuoteHelper::quoteIdentifier($column);
+            return $this->connection->quoteIdentifier($column);
         }, $importOptions->getColumns());
 
         $sql = sprintf(
             'INSERT INTO %s.%s (%s)',
-            QuoteHelper::quoteIdentifier($destination->getSchema()),
-            QuoteHelper::quoteIdentifier($stagingTableName),
+            $this->connection->quoteIdentifier($destination->getSchema()),
+            $this->connection->quoteIdentifier($stagingTableName),
             implode(', ', $quotedColumns)
         );
 
         $sql .= sprintf(
             ' SELECT %s FROM %s.%s',
             implode(', ', $quotedColumns),
-            QuoteHelper::quoteIdentifier($this->source->getSchema()),
-            QuoteHelper::quoteIdentifier($this->source->getTableName())
+            $this->connection->quoteIdentifier($source->getSchema()),
+            $this->connection->quoteIdentifier($source->getTableName())
         );
 
         return [$sql];

--- a/src/Storage/Snowflake/Table.php
+++ b/src/Storage/Snowflake/Table.php
@@ -39,17 +39,6 @@ class Table implements SourceInterface, DestinationInterface, SqlSourceInterface
         throw new NoBackendAdapterException();
     }
 
-    public function getBackendImportAdapter(
-        ImporterInterface $importer
-    ): BackendImportAdapterInterface {
-        switch (true) {
-            case $importer instanceof SnowflakeImporter:
-                return new SnowflakeImportAdapter($this);
-            default:
-                throw new NoBackendAdapterException();
-        }
-    }
-
     public function getFromStatement(): string
     {
         return $this->getQuotedTableWithScheme();

--- a/src/Storage/SourceInterface.php
+++ b/src/Storage/SourceInterface.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\Db\ImportExport\Storage;
 
-use Keboola\Db\ImportExport\Backend\BackendImportAdapterInterface;
-use Keboola\Db\ImportExport\Backend\ImporterInterface;
-
 interface SourceInterface
 {
-    public function getBackendImportAdapter(
-        ImporterInterface $importer
-    ): BackendImportAdapterInterface;
 }

--- a/src/Storage/Synapse/Table.php
+++ b/src/Storage/Synapse/Table.php
@@ -43,17 +43,6 @@ class Table implements SourceInterface, DestinationInterface, SqlSourceInterface
         throw new NoBackendAdapterException();
     }
 
-    public function getBackendImportAdapter(
-        ImporterInterface $importer
-    ): BackendImportAdapterInterface {
-        switch (true) {
-            case $importer instanceof SynapseImporter:
-                return new SynapseImportAdapter($this, $this->platform);
-            default:
-                throw new NoBackendAdapterException();
-        }
-    }
-
     public function getFromStatement(): string
     {
         return $this->getQuotedTableWithScheme();

--- a/tests/unit/Backend/Snowflake/ImporterTest.php
+++ b/tests/unit/Backend/Snowflake/ImporterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\Db\ImportExportUnit\Backend\Snowflake;
+
+use Keboola\Db\ImportExport\Backend\Snowflake\Importer;
+use Keboola\Db\ImportExport\ImportOptions;
+use PHPUnit\Framework\TestCase;
+use Keboola\Db\ImportExport\Storage;
+use Tests\Keboola\Db\ImportExport\ABSSourceTrait;
+
+class ImporterTest extends TestCase
+{
+    use MockConnectionTrait;
+    use ABSSourceTrait;
+
+    public function testGetAdapterMoreThanOneSupports(): void
+    {
+        $source = $this->createDummyABSSourceInstance('');
+        $destination = new Storage\Snowflake\Table('', '');
+
+        $importer = new Importer($this->mockConnection());
+        $importer->setAdapters([Storage\ABS\SnowflakeImportAdapter::class, Storage\ABS\SnowflakeImportAdapter::class]);
+
+        $this->expectExceptionMessage(
+        // phpcs:ignore
+            'More than one suitable adapter found for Snowflake importer with source: "Keboola\Db\ImportExport\Storage\ABS\SourceFile", destination "Keboola\Db\ImportExport\Storage\Snowflake\Table".'
+        );
+        $this->expectException(\Throwable::class);
+        $importer->importTable($source, $destination, new ImportOptions());
+    }
+
+    public function testGetAdapterNoAdapter(): void
+    {
+        $source = $this->createDummyABSSourceInstance('');
+        $destination = new Storage\Snowflake\Table('', '');
+
+        $importer = new Importer($this->mockConnection());
+        $importer->setAdapters([
+            Storage\Snowflake\SnowflakeImportAdapter::class,
+            Storage\Snowflake\SnowflakeImportAdapter::class,
+        ]);
+
+        $this->expectExceptionMessage(
+        // phpcs:ignore
+            'No suitable adapter found for Snowflake importer with source: "Keboola\Db\ImportExport\Storage\ABS\SourceFile", destination "Keboola\Db\ImportExport\Storage\Snowflake\Table".'
+        );
+        $this->expectException(\Throwable::class);
+        $importer->importTable($source, $destination, new ImportOptions());
+    }
+
+    public function testGetAdapterInvalidAdapter(): void
+    {
+        $source = $this->createDummyABSSourceInstance('');
+        $destination = new Storage\Snowflake\Table('', '');
+
+        $importer = new Importer($this->mockConnection());
+        $importer->setAdapters([Storage\Synapse\SynapseImportAdapter::class]);
+
+        $this->expectExceptionMessage(
+        // phpcs:ignore
+            'Each snowflake import adapter must implement "Keboola\Db\ImportExport\Backend\Snowflake\SnowflakeImportAdapterInterface".'
+        );
+        $this->expectException(\Throwable::class);
+        $importer->importTable($source, $destination, new ImportOptions());
+    }
+}

--- a/tests/unit/Backend/Snowflake/MockConnectionTrait.php
+++ b/tests/unit/Backend/Snowflake/MockConnectionTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\Db\ImportExportUnit\Backend\Snowflake;
+
+use Keboola\Db\Import\Snowflake\Connection;
+use Keboola\Db\ImportExport\Backend\Snowflake\Helper\QuoteHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+
+trait MockConnectionTrait
+{
+    /**
+     * @return Connection|MockObject
+     */
+    private function mockConnection()
+    {
+        /** @var Connection|MockObject $mock */
+        $mock = $this->createMock(Connection::class);
+
+        $mock->expects(self::any())->method('quoteIdentifier')->willReturnCallback(static function ($input) {
+            return QuoteHelper::quoteIdentifier($input);
+        });
+
+        return $mock;
+    }
+}

--- a/tests/unit/Backend/Synapse/ImporterTest.php
+++ b/tests/unit/Backend/Synapse/ImporterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\Db\ImportExportUnit\Backend\Synapse;
+
+use Keboola\Db\ImportExport\Backend\Synapse\Importer;
+use Keboola\Db\ImportExport\ImportOptions;
+use PHPUnit\Framework\TestCase;
+use Keboola\Db\ImportExport\Storage;
+use Tests\Keboola\Db\ImportExport\ABSSourceTrait;
+
+class ImporterTest extends TestCase
+{
+    use MockConnectionTrait;
+    use ABSSourceTrait;
+
+    public function testGetAdapterMoreThanOneSupports(): void
+    {
+        $source = $this->createDummyABSSourceInstance('');
+        $destination = new Storage\Synapse\Table('', '');
+
+        $importer = new Importer($this->mockConnection());
+        $importer->setAdapters([Storage\ABS\SynapseImportAdapter::class, Storage\ABS\SynapseImportAdapter::class]);
+
+        $this->expectExceptionMessage(
+        // phpcs:ignore
+            'More than one suitable adapter found for Synapse importer with source: "Keboola\Db\ImportExport\Storage\ABS\SourceFile", destination "Keboola\Db\ImportExport\Storage\Synapse\Table".'
+        );
+        $this->expectException(\Throwable::class);
+        $importer->importTable($source, $destination, new ImportOptions());
+    }
+
+    public function testGetAdapterNoAdapter(): void
+    {
+        $source = $this->createDummyABSSourceInstance('');
+        $destination = new Storage\Synapse\Table('', '');
+
+        $importer = new Importer($this->mockConnection());
+        $importer->setAdapters([
+            Storage\Synapse\SynapseImportAdapter::class,
+            Storage\Synapse\SynapseImportAdapter::class,
+        ]);
+
+        $this->expectExceptionMessage(
+        // phpcs:ignore
+            'No suitable adapter found for Synapse importer with source: "Keboola\Db\ImportExport\Storage\ABS\SourceFile", destination "Keboola\Db\ImportExport\Storage\Synapse\Table".'
+        );
+        $this->expectException(\Throwable::class);
+        $importer->importTable($source, $destination, new ImportOptions());
+    }
+
+    public function testGetAdapterInvalidAdapter(): void
+    {
+        $source = $this->createDummyABSSourceInstance('');
+        $destination = new Storage\Synapse\Table('', '');
+
+        $importer = new Importer($this->mockConnection());
+        $importer->setAdapters([Storage\Snowflake\SnowflakeImportAdapter::class]);
+
+        $this->expectExceptionMessage(
+        // phpcs:ignore
+            'Each Synapse import adapter must implement "Keboola\Db\ImportExport\Backend\Synapse\SynapseImportAdapterInterface".'
+        );
+        $this->expectException(\Throwable::class);
+        $importer->importTable($source, $destination, new ImportOptions());
+    }
+}

--- a/tests/unit/Backend/Synapse/MockConnectionTrait.php
+++ b/tests/unit/Backend/Synapse/MockConnectionTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\Db\ImportExportUnit\Backend\Synapse;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Keboola\Db\ImportExport\Backend\Snowflake\Helper\QuoteHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+
+trait MockConnectionTrait
+{
+    /**
+     * @return Connection|MockObject
+     */
+    private function mockConnection()
+    {
+        /** @var Connection|MockObject $mock */
+        $mock = $this->createMock(Connection::class);
+        $mock->expects($this->any())->method('getDatabasePlatform')->willReturn(
+            new SQLServer2012Platform()
+        );
+        $mock->expects($this->any())->method('quote')->willReturnCallback(static function ($input) {
+            return QuoteHelper::quote($input);
+        });
+
+        return $mock;
+    }
+}

--- a/tests/unit/SourceStorage/ABS/BaseFileTest.php
+++ b/tests/unit/SourceStorage/ABS/BaseFileTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Keboola\Db\ImportExportUnit\Storage\ABS;
 
 use Keboola\Db\ImportExport\Storage;
+use Keboola\Db\ImportExport\Storage\ABS\BaseFile;
 use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;
 
 class BaseFileTest extends BaseTestCase
@@ -21,7 +22,7 @@ class BaseFileTest extends BaseTestCase
         self::assertEquals('file.csv', $baseFile->getFilePath());
         self::assertEquals(
             'azure://absAccount.blob.core.windows.net/absContainer/',
-            $baseFile->getContainerUrl()
+            $baseFile->getContainerUrl($baseFile::PROTOCOL_AZURE)
         );
         self::assertEquals(
             'https://absAccount.blob.core.windows.net/absContainer/',

--- a/tests/unit/SourceStorage/ABS/SnowflakeImportAdapterTest.php
+++ b/tests/unit/SourceStorage/ABS/SnowflakeImportAdapterTest.php
@@ -5,17 +5,47 @@ declare(strict_types=1);
 namespace Tests\Keboola\Db\ImportExportUnit\Storage\ABS;
 
 use Keboola\CsvOptions\CsvOptions;
-use Keboola\Db\Import\Snowflake\Connection;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\ABS\SnowflakeImportAdapter;
 use Keboola\Db\ImportExport\Storage;
 use PHPUnit\Framework\MockObject\MockObject;
+use Tests\Keboola\Db\ImportExport\ABSSourceTrait;
 use Tests\Keboola\Db\ImportExportUnit\Backend\Snowflake\MockConnectionTrait;
 use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;
 
 class SnowflakeImportAdapterTest extends BaseTestCase
 {
     use MockConnectionTrait;
+    use ABSSourceTrait;
+
+    public function testIsSupported(): void
+    {
+        $absSource = $this->createDummyABSSourceInstance('');
+        $snowflakeTable = new Storage\Snowflake\Table('', '');
+        $snowflakeSelectSource = new Storage\Snowflake\SelectSource('', []);
+        $synapseTable = new Storage\Synapse\Table('', '');
+
+        $this->assertTrue(
+            SnowflakeImportAdapter::isSupported(
+                $absSource,
+                $snowflakeTable
+            )
+        );
+
+        $this->assertFalse(
+            SnowflakeImportAdapter::isSupported(
+                $snowflakeSelectSource,
+                $snowflakeTable
+            )
+        );
+
+        $this->assertFalse(
+            SnowflakeImportAdapter::isSupported(
+                $absSource,
+                $synapseTable
+            )
+        );
+    }
 
     public function testGetCopyCommands(): void
     {

--- a/tests/unit/SourceStorage/ABS/SnowflakeImportAdapterTest.php
+++ b/tests/unit/SourceStorage/ABS/SnowflakeImportAdapterTest.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace Tests\Keboola\Db\ImportExportUnit\Storage\ABS;
 
 use Keboola\CsvOptions\CsvOptions;
+use Keboola\Db\Import\Snowflake\Connection;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\ABS\SnowflakeImportAdapter;
 use Keboola\Db\ImportExport\Storage;
 use PHPUnit\Framework\MockObject\MockObject;
+use Tests\Keboola\Db\ImportExportUnit\Backend\Snowflake\MockConnectionTrait;
 use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;
 
 class SnowflakeImportAdapterTest extends BaseTestCase
 {
+    use MockConnectionTrait;
+
     public function testGetCopyCommands(): void
     {
         /** @var Storage\ABS\SourceFile|MockObject $source */
@@ -24,8 +28,9 @@ class SnowflakeImportAdapterTest extends BaseTestCase
 
         $destination = new Storage\Snowflake\Table('schema', 'table');
         $options = new ImportOptions();
-        $adapter = new SnowflakeImportAdapter($source);
+        $adapter = new SnowflakeImportAdapter($this->mockConnection());
         $commands = $adapter->getCopyCommands(
+            $source,
             $destination,
             $options,
             'stagingTable'
@@ -60,8 +65,9 @@ EOT
 
         $destination = new Storage\Snowflake\Table('schema', 'table');
         $options = new ImportOptions();
-        $adapter = new SnowflakeImportAdapter($source);
+        $adapter = new SnowflakeImportAdapter($this->mockConnection());
         $commands = $adapter->getCopyCommands(
+            $source,
             $destination,
             $options,
             'stagingTable'

--- a/tests/unit/SourceStorage/ABS/SourceFileTest.php
+++ b/tests/unit/SourceStorage/ABS/SourceFileTest.php
@@ -29,33 +29,6 @@ class SourceFileTest extends BaseTestCase
         self::assertEquals('file.csv', $source->getFilePath());
     }
 
-    public function testGetBackendImportAdapter(): void
-    {
-        $source = $this->createDummyABSSourceInstance('file.csv');
-        /** @var SnowflakeImporter|MockObject $importer */
-        $importer = self::createMock(SnowflakeImporter::class);
-        $adapter = $source->getBackendImportAdapter($importer);
-        self::assertInstanceOf(BackendImportAdapterInterface::class, $adapter);
-        self::assertInstanceOf(SnowflakeImportAdapter::class, $adapter);
-    }
-
-    public function testGetBackendImportAdapterInvalidImporter(): void
-    {
-        $source = $this->createDummyABSSourceInstance('file.csv');
-        $dummyImporter = new class implements ImporterInterface {
-            public function importTable(
-                Storage\SourceInterface $source,
-                Storage\DestinationInterface $destination,
-                ImportOptions $options
-            ): Result {
-                return new Result([]);
-            }
-        };
-
-        self::expectException(NoBackendAdapterException::class);
-        $source->getBackendImportAdapter($dummyImporter);
-    }
-
     public function testGetManifestEntries(): void
     {
         $source = $this->createABSSourceInstance('file.csv');

--- a/tests/unit/SourceStorage/ABS/SynapseImportAdapterTest.php
+++ b/tests/unit/SourceStorage/ABS/SynapseImportAdapterTest.php
@@ -12,10 +12,42 @@ use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\ABS\SynapseImportAdapter;
 use Keboola\Db\ImportExport\Storage;
 use PHPUnit\Framework\MockObject\MockObject;
+use Tests\Keboola\Db\ImportExport\ABSSourceTrait;
 use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;
 
 class SynapseImportAdapterTest extends BaseTestCase
 {
+    use ABSSourceTrait;
+
+    public function testIsSupported(): void
+    {
+        $absSource = $this->createDummyABSSourceInstance('');
+        $snowflakeTable = new Storage\Snowflake\Table('', '');
+        $snowflakeSelectSource = new Storage\Snowflake\SelectSource('', []);
+        $synapseTable = new Storage\Synapse\Table('', '');
+
+        $this->assertTrue(
+            SynapseImportAdapter::isSupported(
+                $absSource,
+                $synapseTable
+            )
+        );
+
+        $this->assertFalse(
+            SynapseImportAdapter::isSupported(
+                $snowflakeSelectSource,
+                $snowflakeTable
+            )
+        );
+
+        $this->assertFalse(
+            SynapseImportAdapter::isSupported(
+                $absSource,
+                $snowflakeTable
+            )
+        );
+    }
+
     public function testGetCopyCommands(): void
     {
         /** @var Storage\ABS\SourceFile|MockObject $source */

--- a/tests/unit/SourceStorage/ABS/SynapseImportAdapterTest.php
+++ b/tests/unit/SourceStorage/ABS/SynapseImportAdapterTest.php
@@ -35,12 +35,12 @@ class SynapseImportAdapterTest extends BaseTestCase
 
         $destination = new Storage\Synapse\Table('schema', 'table');
         $options = new ImportOptions();
-        $adapter = new SynapseImportAdapter($source);
+        $adapter = new SynapseImportAdapter($conn);
         $commands = $adapter->getCopyCommands(
+            $source,
             $destination,
             $options,
-            'stagingTable',
-            $conn
+            'stagingTable'
         );
 
         $this->assertSame([
@@ -81,12 +81,12 @@ EOT
 
         $destination = new Storage\Synapse\Table('schema', 'table');
         $options = new ImportOptions([], [], false, false, 1);
-        $adapter = new SynapseImportAdapter($source);
+        $adapter = new SynapseImportAdapter($conn);
         $commands = $adapter->getCopyCommands(
+            $source,
             $destination,
             $options,
-            'stagingTable',
-            $conn
+            'stagingTable'
         );
 
         $this->assertSame([

--- a/tests/unit/SourceStorage/Snowflake/SelectSourceTest.php
+++ b/tests/unit/SourceStorage/Snowflake/SelectSourceTest.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Keboola\Db\ImportExportUnit\Storage\Snowflake;
 
-use Keboola\Db\Import\Result;
-use Keboola\Db\ImportExport\Backend\ImporterInterface;
-use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage;
-use Keboola\Db\ImportExport\Storage\NoBackendAdapterException;
 use PHPUnit\Framework\TestCase;
 
 class SelectSourceTest extends TestCase
@@ -20,16 +16,5 @@ class SelectSourceTest extends TestCase
         $this->assertEquals('(SELECT * FROM "SCHEMA"."TABLE")', $source->getFromStatement());
         $this->assertEquals('SELECT * FROM "SCHEMA"."TABLE"', $source->getQuery());
         $this->assertSame(['prop' => 1], $source->getQueryBindings());
-
-        $this->expectException(NoBackendAdapterException::class);
-        $source->getBackendImportAdapter((new class implements ImporterInterface {
-            public function importTable(
-                Storage\SourceInterface $source,
-                Storage\DestinationInterface $destination,
-                ImportOptions $options
-            ): Result {
-                // only a stub
-            }
-        }));
     }
 }

--- a/tests/unit/SourceStorage/Snowflake/SnowflakeAdapterTest.php
+++ b/tests/unit/SourceStorage/Snowflake/SnowflakeAdapterTest.php
@@ -8,10 +8,13 @@ use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\Snowflake\SnowflakeImportAdapter;
 use Keboola\Db\ImportExport\Storage;
 use PHPUnit\Framework\MockObject\MockObject;
+use Tests\Keboola\Db\ImportExportUnit\Backend\Snowflake\MockConnectionTrait;
 use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;
 
 class SnowflakeAdapterTest extends BaseTestCase
 {
+    use MockConnectionTrait;
+
     public function testGetCopyCommands(): void
     {
         /** @var Storage\Snowflake\Table|MockObject $source */
@@ -21,8 +24,9 @@ class SnowflakeAdapterTest extends BaseTestCase
 
         $destination = new Storage\Snowflake\Table('schema', 'table');
         $options = new ImportOptions([], ['col1', 'col2']);
-        $adapter = new SnowflakeImportAdapter($source);
+        $adapter = new SnowflakeImportAdapter($this->mockConnection());
         $commands = $adapter->getCopyCommands(
+            $source,
             $destination,
             $options,
             'stagingTable'

--- a/tests/unit/SourceStorage/Snowflake/SnowflakeAdapterTest.php
+++ b/tests/unit/SourceStorage/Snowflake/SnowflakeAdapterTest.php
@@ -7,13 +7,52 @@ namespace Tests\Keboola\Db\ImportExportUnit\Storage\Snowflake;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\Snowflake\SnowflakeImportAdapter;
 use Keboola\Db\ImportExport\Storage;
+use Keboola\Db\ImportExport\Storage\Synapse\SynapseImportAdapter;
 use PHPUnit\Framework\MockObject\MockObject;
+use Tests\Keboola\Db\ImportExport\ABSSourceTrait;
 use Tests\Keboola\Db\ImportExportUnit\Backend\Snowflake\MockConnectionTrait;
 use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;
 
 class SnowflakeAdapterTest extends BaseTestCase
 {
     use MockConnectionTrait;
+    use ABSSourceTrait;
+
+    public function testIsSupported(): void
+    {
+        $absSource = $this->createDummyABSSourceInstance('');
+        $snowflakeTable = new Storage\Snowflake\Table('', '');
+        $snowflakeSelectSource = new Storage\Snowflake\SelectSource('', []);
+        $synapseTable = new Storage\Synapse\Table('', '');
+
+        $this->assertTrue(
+            SnowflakeImportAdapter::isSupported(
+                $snowflakeTable,
+                $snowflakeTable
+            )
+        );
+
+        $this->assertFalse(
+            SnowflakeImportAdapter::isSupported(
+                $snowflakeSelectSource,
+                $synapseTable
+            )
+        );
+
+        $this->assertFalse(
+            SnowflakeImportAdapter::isSupported(
+                $absSource,
+                $synapseTable
+            )
+        );
+
+        $this->assertFalse(
+            SynapseImportAdapter::isSupported(
+                $snowflakeTable,
+                $synapseTable
+            )
+        );
+    }
 
     public function testGetCopyCommands(): void
     {

--- a/tests/unit/SourceStorage/Snowflake/TableTest.php
+++ b/tests/unit/SourceStorage/Snowflake/TableTest.php
@@ -35,31 +35,4 @@ class TableTest extends TestCase
         self::expectException(NoBackendAdapterException::class);
         $source->getBackendExportAdapter($exporter);
     }
-
-    public function testGetBackendImportAdapter(): void
-    {
-        $source = new Storage\Snowflake\Table('schema', 'table');
-        /** @var SnowflakeImporter|MockObject $importer */
-        $importer = self::createMock(SnowflakeImporter::class);
-        $adapter = $source->getBackendImportAdapter($importer);
-        self::assertInstanceOf(BackendImportAdapterInterface::class, $adapter);
-        self::assertInstanceOf(Storage\Snowflake\SnowflakeImportAdapter::class, $adapter);
-    }
-
-    public function testGetBackendImportAdapterInvalidImporter(): void
-    {
-        $source = new Storage\Snowflake\Table('schema', 'table');
-        $dummyImporter = new class implements ImporterInterface {
-            public function importTable(
-                Storage\SourceInterface $source,
-                Storage\DestinationInterface $destination,
-                ImportOptions $options
-            ): Result {
-                return new Result([]);
-            }
-        };
-
-        self::expectException(NoBackendAdapterException::class);
-        $source->getBackendImportAdapter($dummyImporter);
-    }
 }

--- a/tests/unit/SourceStorage/Synapse/SynapseAdapterTest.php
+++ b/tests/unit/SourceStorage/Synapse/SynapseAdapterTest.php
@@ -10,10 +10,49 @@ use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\Synapse\SynapseImportAdapter;
 use Keboola\Db\ImportExport\Storage;
 use PHPUnit\Framework\MockObject\MockObject;
+use Tests\Keboola\Db\ImportExport\ABSSourceTrait;
 use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;
 
 class SynapseAdapterTest extends BaseTestCase
 {
+    use ABSSourceTrait;
+
+    public function testIsSupported(): void
+    {
+        $absSource = $this->createDummyABSSourceInstance('');
+        $snowflakeTable = new Storage\Snowflake\Table('', '');
+        $snowflakeSelectSource = new Storage\Snowflake\SelectSource('', []);
+        $synapseTable = new Storage\Synapse\Table('', '');
+
+        $this->assertTrue(
+            SynapseImportAdapter::isSupported(
+                $synapseTable,
+                $synapseTable
+            )
+        );
+
+        $this->assertFalse(
+            SynapseImportAdapter::isSupported(
+                $snowflakeSelectSource,
+                $snowflakeTable
+            )
+        );
+
+        $this->assertFalse(
+            SynapseImportAdapter::isSupported(
+                $absSource,
+                $snowflakeTable
+            )
+        );
+
+        $this->assertFalse(
+            SynapseImportAdapter::isSupported(
+                $snowflakeTable,
+                $synapseTable
+            )
+        );
+    }
+
     public function testGetCopyCommands(): void
     {
         /** @var Storage\Synapse\Table|MockObject $source */

--- a/tests/unit/SourceStorage/Synapse/SynapseAdapterTest.php
+++ b/tests/unit/SourceStorage/Synapse/SynapseAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Keboola\Db\ImportExportUnit\Storage\Synapse;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\Synapse\SynapseImportAdapter;
@@ -20,10 +21,17 @@ class SynapseAdapterTest extends BaseTestCase
         $source->expects(self::once())->method('getSchema')->willReturn('schema');
         $source->expects(self::once())->method('getTableName')->willReturn('table');
 
+        /** @var Connection|MockObject $source */
+        $conn = $this->createMock(Connection::class);
+        $conn->expects($this->once())->method('getDatabasePlatform')->willReturn(
+            new SQLServer2012Platform()
+        );
+
         $destination = new Storage\Synapse\Table('schema', 'table');
         $options = new ImportOptions([], ['col1', 'col2']);
-        $adapter = new SynapseImportAdapter($source, new SQLServer2012Platform());
+        $adapter = new SynapseImportAdapter($conn);
         $commands = $adapter->getCopyCommands(
+            $source,
             $destination,
             $options,
             'stagingTable'

--- a/tests/unit/SourceStorage/Synapse/TableTest.php
+++ b/tests/unit/SourceStorage/Synapse/TableTest.php
@@ -25,33 +25,4 @@ class TableTest extends TestCase
         self::assertEquals([], $source->getQueryBindings());
         self::assertEquals('[schema].[table]', $source->getFromStatement());
     }
-
-//  TODO: Export adapter
-
-    public function testGetBackendImportAdapter(): void
-    {
-        $source = new Storage\Synapse\Table('schema', 'table');
-        /** @var SynapseImporter|MockObject $importer */
-        $importer = self::createMock(SynapseImporter::class);
-        $adapter = $source->getBackendImportAdapter($importer);
-        self::assertInstanceOf(BackendImportAdapterInterface::class, $adapter);
-        self::assertInstanceOf(Storage\Synapse\SynapseImportAdapter::class, $adapter);
-    }
-
-    public function testGetBackendImportAdapterInvalidImporter(): void
-    {
-        $source = new Storage\Synapse\Table('schema', 'table');
-        $dummyImporter = new class implements ImporterInterface {
-            public function importTable(
-                Storage\SourceInterface $source,
-                Storage\DestinationInterface $destination,
-                ImportOptions $options
-            ): Result {
-                return new Result([]);
-            }
-        };
-
-        self::expectException(NoBackendAdapterException::class);
-        $source->getBackendImportAdapter($dummyImporter);
-    }
 }


### PR DESCRIPTION
Importer teď má seznam default adaptérů, který teď už není součástí source.
Adaptér má metodu `isSupported` a kontroluje teda jestli je Source, Destination může zpracovávat.
Adaptéry jdou nastavit pomocí metody `setAdapters` v Importeru.
Importer projde adaptéry a zkotroluje jestli je v seznamu použitélný adaptér.