### PR TITLE
Synapse fix temp table definition as HEAP

### DIFF
--- a/src/Backend/Synapse/SqlCommandBuilder.php
+++ b/src/Backend/Synapse/SqlCommandBuilder.php
@@ -57,10 +57,10 @@ class SqlCommandBuilder
     ): string {
         $this->assertStagingTable($tableName);
         $columnsSql = array_map(function ($column) {
-            return sprintf('%s nvarchar(4000)', $this->platform->quoteSingleIdentifier($column));
+            return sprintf('%s nvarchar(max)', $this->platform->quoteSingleIdentifier($column));
         }, $columns);
         return sprintf(
-            'CREATE TABLE %s.%s (%s) WITH (LOCATION = USER_DB)',
+            'CREATE TABLE %s.%s (%s) WITH (HEAP, LOCATION = USER_DB)',
             $this->platform->quoteSingleIdentifier($schema),
             $this->platform->quoteSingleIdentifier($tableName),
             implode(', ', $columnsSql)

--- a/tests/functional/Synapse/SqlCommandBuilderTest.php
+++ b/tests/functional/Synapse/SqlCommandBuilderTest.php
@@ -45,7 +45,7 @@ class SqlCommandBuilderTest extends SynapseBaseTestCase
 
         $this->assertEquals(
         // phpcs:ignore
-            'CREATE TABLE [import-export-test_schema].[#import-export-test_test] ([col1] nvarchar(4000), [col2] nvarchar(4000)) WITH (LOCATION = USER_DB)',
+            'CREATE TABLE [import-export-test_schema].[#import-export-test_test] ([col1] nvarchar(max), [col2] nvarchar(max)) WITH (HEAP, LOCATION = USER_DB)',
             $sql
         );
         $this->connection->exec($sql);


### PR DESCRIPTION
HEAP table allows to use nvarchar(max) to store more than 4000bitepairs