### PR TITLE
fix namespace missing \Backend\

### DIFF
--- a/src/Backend/Synapse/PolyBaseCommandBuilder.php
+++ b/src/Backend/Synapse/PolyBaseCommandBuilder.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Keboola\Db\ImportExport\Storage;
-use Keboola\Db\ImportExport\Synapse\SynapseExportOptions;
 
 class PolyBaseCommandBuilder
 {

--- a/src/Backend/Synapse/SynapseExportOptions.php
+++ b/src/Backend/Synapse/SynapseExportOptions.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Keboola\Db\ImportExport\Synapse;
+namespace Keboola\Db\ImportExport\Backend\Synapse;
 
 use Keboola\Db\ImportExport\ExportOptions;
 

--- a/src/Backend/Synapse/SynapseImportOptions.php
+++ b/src/Backend/Synapse/SynapseImportOptions.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Keboola\Db\ImportExport\Synapse;
+namespace Keboola\Db\ImportExport\Backend\Synapse;
 
 use Keboola\Db\ImportExport\ImportOptions;
 

--- a/src/Storage/ABS/BaseFile.php
+++ b/src/Storage/ABS/BaseFile.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\Db\ImportExport\Storage\ABS;
 
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseExportOptions;
+
 abstract class BaseFile
 {
     public const PROTOCOL_AZURE = 'azure';
@@ -60,8 +62,15 @@ abstract class BaseFile
         );
     }
 
-    public function getPolyBaseUrl(): string
+    public function getPolyBaseUrl(string $credentialsType): string
     {
+        if ($credentialsType === SynapseExportOptions::CREDENTIALS_MANAGED_IDENTITY) {
+            return sprintf(
+                'abfss://%s@%s.dfs.core.windows.net/',
+                $this->container,
+                $this->accountName
+            );
+        }
         return sprintf(
             'wasbs://%s@%s.blob.core.windows.net/',
             $this->container,

--- a/src/Storage/ABS/SynapseExportAdapter.php
+++ b/src/Storage/ABS/SynapseExportAdapter.php
@@ -9,7 +9,7 @@ use Keboola\Db\ImportExport\Backend\Synapse\PolyBaseCommandBuilder;
 use Keboola\Db\ImportExport\Backend\Synapse\SynapseExportAdapterInterface;
 use Keboola\Db\ImportExport\ExportOptionsInterface;
 use Keboola\Db\ImportExport\Storage;
-use Keboola\Db\ImportExport\Synapse\SynapseExportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseExportOptions;
 
 class SynapseExportAdapter implements SynapseExportAdapterInterface
 {

--- a/src/Storage/ABS/SynapseExportAdapter.php
+++ b/src/Storage/ABS/SynapseExportAdapter.php
@@ -53,7 +53,7 @@ class SynapseExportAdapter implements SynapseExportAdapterInterface
         $dateFormat = 'yyyy-MM-dd HH:mm:ss';
         $exportId = $exportOptions->getExportId();
         $blobMasterKey = $destination->getBlobMasterKey();
-        $containerUrl = $destination->getPolyBaseUrl();
+        $containerUrl = $destination->getPolyBaseUrl($exportOptions->getExportCredentialsType());
         $credentialsId = $exportId . '_StorageCredential';
         $dataSourceId = $exportId . '_StorageSource';
         $fileFormatId = $exportId . '_StorageFileFormat';

--- a/src/Storage/ABS/SynapseImportAdapter.php
+++ b/src/Storage/ABS/SynapseImportAdapter.php
@@ -10,7 +10,7 @@ use Keboola\Db\ImportExport\Backend\Synapse\SqlCommandBuilder;
 use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportAdapterInterface;
 use Keboola\Db\ImportExport\ImportOptionsInterface;
 use Keboola\Db\ImportExport\Storage;
-use Keboola\Db\ImportExport\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 
 class SynapseImportAdapter implements SynapseImportAdapterInterface
 {

--- a/tests/functional/Synapse/ExportTest.php
+++ b/tests/functional/Synapse/ExportTest.php
@@ -77,7 +77,7 @@ class ExportTest extends SynapseBaseTestCase
 
         // export
         $source = $destination;
-        $options = new SynapseExportOptions(true);
+        $options = new SynapseExportOptions(true, getenv('CREDENTIALS_EXPORT_TYPE'));
         $destinationBlob = $this->getExportBlobDir() . '/gz_test/';
         $destination = $this->createABSSourceDestinationInstance($destinationBlob);
 
@@ -126,7 +126,7 @@ class ExportTest extends SynapseBaseTestCase
 
         // export
         $source = $destination;
-        $options = new SynapseExportOptions();
+        $options = new SynapseExportOptions(false, getenv('CREDENTIALS_EXPORT_TYPE'));
         $destinationBlob = $this->getExportBlobDir() . '/ts_test/';
         $destination = $this->createABSSourceDestinationInstance($destinationBlob);
 
@@ -209,7 +209,7 @@ class ExportTest extends SynapseBaseTestCase
             $destination->getQuotedTableWithScheme()
         );
         $source = new Storage\Synapse\SelectSource($query);
-        $options = new SynapseExportOptions();
+        $options = new SynapseExportOptions(false, getenv('CREDENTIALS_EXPORT_TYPE'));
         $destinationBlob = $this->getExportBlobDir() . '/tw_test/';
         $destination = $this->createABSSourceDestinationInstance($this->getExportBlobDir() . '/tw_test');
 
@@ -263,7 +263,7 @@ class ExportTest extends SynapseBaseTestCase
             $destination->getQuotedTableWithScheme()
         );
         $source = new Storage\Synapse\SelectSource($query, [15]);
-        $options = new SynapseExportOptions();
+        $options = new SynapseExportOptions(false, getenv('CREDENTIALS_EXPORT_TYPE'));
         $destinationBlob = $this->getExportBlobDir() . '/tw_test/';
         $destination = $this->createABSSourceDestinationInstance($this->getExportBlobDir() . '/tw_test');
 

--- a/tests/functional/Synapse/ExportTest.php
+++ b/tests/functional/Synapse/ExportTest.php
@@ -9,7 +9,7 @@ use Keboola\Csv\CsvFile;
 use Keboola\Db\ImportExport\Backend\Synapse\Exporter;
 use Keboola\Db\ImportExport\Backend\Synapse\Importer;
 use Keboola\Db\ImportExport\Storage;
-use Keboola\Db\ImportExport\Synapse\SynapseExportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseExportOptions;
 use Keboola\Temp\Temp;
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use MicrosoftAzure\Storage\Blob\Models\ListBlobsOptions;

--- a/tests/functional/Synapse/FullImportTest.php
+++ b/tests/functional/Synapse/FullImportTest.php
@@ -9,7 +9,7 @@ use Keboola\CsvOptions\CsvOptions;
 use Keboola\Db\ImportExport\Backend\Synapse\Importer;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage;
-use Keboola\Db\ImportExport\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 
 class FullImportTest extends SynapseBaseTestCase
 {

--- a/tests/functional/Synapse/IncrementalImportTest.php
+++ b/tests/functional/Synapse/IncrementalImportTest.php
@@ -8,7 +8,7 @@ use Keboola\Csv\CsvFile;
 use Keboola\Db\ImportExport\Backend\Synapse\Importer;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage;
-use Keboola\Db\ImportExport\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 
 class IncrementalImportTest extends SynapseBaseTestCase
 {

--- a/tests/functional/Synapse/OtherImportTest.php
+++ b/tests/functional/Synapse/OtherImportTest.php
@@ -10,7 +10,7 @@ use Keboola\Db\Import\Exception;
 use Keboola\Db\ImportExport\Backend\Synapse\Importer;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage;
-use Keboola\Db\ImportExport\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 
 class OtherImportTest extends SynapseBaseTestCase
 {

--- a/tests/functional/Synapse/SqlCommandBuilderTest.php
+++ b/tests/functional/Synapse/SqlCommandBuilderTest.php
@@ -8,7 +8,7 @@ use DateTime;
 use Keboola\Db\ImportExport\Backend\Snowflake\Helper\DateTimeHelper;
 use Keboola\Db\ImportExport\Storage\SourceInterface;
 use Keboola\Db\ImportExport\Storage\Synapse\Table;
-use Keboola\Db\ImportExport\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 
 class SqlCommandBuilderTest extends SynapseBaseTestCase
 {

--- a/tests/functional/Synapse/SynapseBaseTestCase.php
+++ b/tests/functional/Synapse/SynapseBaseTestCase.php
@@ -11,7 +11,7 @@ use Keboola\Db\ImportExport\Backend\Synapse\SqlCommandBuilder;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\SourceInterface;
 use Keboola\Db\ImportExport\Storage\Synapse\Table;
-use Keboola\Db\ImportExport\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 use Tests\Keboola\Db\ImportExportFunctional\ImportExportBaseTest;
 
 class SynapseBaseTestCase extends ImportExportBaseTest

--- a/tests/unit/Backend/Synapse/SynapseExportOptionsTest.php
+++ b/tests/unit/Backend/Synapse/SynapseExportOptionsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Keboola\Db\ImportExportUnit\Backend\Synapse;
 
-use Keboola\Db\ImportExport\Synapse\SynapseExportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseExportOptions;
 use PHPUnit\Framework\TestCase;
 
 class SynapseExportOptionsTest extends TestCase

--- a/tests/unit/Backend/Synapse/SynapseImportOptionsTest.php
+++ b/tests/unit/Backend/Synapse/SynapseImportOptionsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Keboola\Db\ImportExportUnit\Backend\Synapse;
 
-use Keboola\Db\ImportExport\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 use PHPUnit\Framework\TestCase;
 
 class SynapseImportOptionsTest extends TestCase

--- a/tests/unit/Storage/ABS/SynapseExportAdapterTest.php
+++ b/tests/unit/Storage/ABS/SynapseExportAdapterTest.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDOSqlsrv;
 use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Keboola\Db\ImportExport\ExportOptions;
-use Keboola\Db\ImportExport\Synapse\SynapseExportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseExportOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use Keboola\Db\ImportExport\Storage;
 use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;

--- a/tests/unit/Storage/ABS/SynapseImportAdapterTest.php
+++ b/tests/unit/Storage/ABS/SynapseImportAdapterTest.php
@@ -7,7 +7,7 @@ namespace Tests\Keboola\Db\ImportExportUnit\Storage\ABS;
 use Keboola\CsvOptions\CsvOptions;
 use Keboola\Db\ImportExport\Storage\ABS\SynapseImportAdapter;
 use Keboola\Db\ImportExport\Storage;
-use Keboola\Db\ImportExport\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use Tests\Keboola\Db\ImportExport\ABSSourceTrait;
 use Tests\Keboola\Db\ImportExportUnit\Backend\Synapse\MockConnectionTrait;


### PR DESCRIPTION
- fix namespace for Synapse{Import,Export}Options
- fix exports test to work with managed identity
- fix DestinationFile to support different protocol and domain for managed identity