### PR TITLE
KBC-1251 optimize full import in synapse - part1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "keboola/csv-options": "^1",
         "keboola/php-csv-db-import": "^5.0",
         "keboola/php-file-storage-utils": "^0.1.0",
+        "keboola/table-backend-utils": "^0.5.1",
         "microsoft/azure-storage-blob": "^1.4"
     },
     "require-dev": {

--- a/src/Backend/ImporterInterface.php
+++ b/src/Backend/ImporterInterface.php
@@ -10,6 +10,7 @@ use Keboola\Db\ImportExport\Storage;
 
 interface ImporterInterface
 {
+    public const TIMESTAMP_COLUMN_NAME = '_timestamp';
     public const SLICED_FILES_CHUNK_SIZE = 1000;
 
     public function importTable(

--- a/src/Backend/Snowflake/Importer.php
+++ b/src/Backend/Snowflake/Importer.php
@@ -16,8 +16,6 @@ use Keboola\Db\ImportExport\Storage;
 
 class Importer implements ImporterInterface
 {
-    public const TIMESTAMP_COLUMN_NAME = '_timestamp';
-
     public const DEFAULT_ADAPTERS = [
         Storage\ABS\SnowflakeImportAdapter::class,
         Storage\Snowflake\SnowflakeImportAdapter::class,

--- a/src/Backend/Synapse/DestinationTableOptions.php
+++ b/src/Backend/Synapse/DestinationTableOptions.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Db\ImportExport\Backend\Synapse;
+
+final class DestinationTableOptions
+{
+    public const PRIMARY_KEYS_DEFINITION_METADATA = 'METADATA';
+    public const PRIMARY_KEYS_DEFINITION_DB = 'DB';
+
+    /** @var String[] */
+    private $columnNamesInOrder;
+
+    /** @var String[] */
+    private $primaryKeys;
+
+    /** @var string */
+    private $primaryKeysDefinition;
+
+    /**
+     * @param String[] $columnNamesInOrder
+     * @param String[] $primaryKeys
+     */
+    public function __construct(
+        array $columnNamesInOrder,
+        array $primaryKeys,
+        string $primaryKeysDefinition
+    ) {
+        $this->columnNamesInOrder = $columnNamesInOrder;
+        $this->primaryKeys = $primaryKeys;
+        $this->primaryKeysDefinition = $primaryKeysDefinition;
+    }
+
+    public function isPrimaryKeyFromMetadata(): bool
+    {
+        return $this->primaryKeysDefinition === self::PRIMARY_KEYS_DEFINITION_METADATA;
+    }
+
+    public function getColumnNamesInOrder(): array
+    {
+        return $this->columnNamesInOrder;
+    }
+
+    public function getPrimaryKeys(): array
+    {
+        return $this->primaryKeys;
+    }
+}

--- a/src/Backend/Synapse/DestinationTableOptions.php
+++ b/src/Backend/Synapse/DestinationTableOptions.php
@@ -4,19 +4,16 @@ declare(strict_types=1);
 
 namespace Keboola\Db\ImportExport\Backend\Synapse;
 
+/**
+ * @internal
+ */
 final class DestinationTableOptions
 {
-    public const PRIMARY_KEYS_DEFINITION_METADATA = 'METADATA';
-    public const PRIMARY_KEYS_DEFINITION_DB = 'DB';
-
     /** @var String[] */
     private $columnNamesInOrder;
 
     /** @var String[] */
     private $primaryKeys;
-
-    /** @var string */
-    private $primaryKeysDefinition;
 
     /**
      * @param String[] $columnNamesInOrder
@@ -24,17 +21,10 @@ final class DestinationTableOptions
      */
     public function __construct(
         array $columnNamesInOrder,
-        array $primaryKeys,
-        string $primaryKeysDefinition
+        array $primaryKeys
     ) {
         $this->columnNamesInOrder = $columnNamesInOrder;
         $this->primaryKeys = $primaryKeys;
-        $this->primaryKeysDefinition = $primaryKeysDefinition;
-    }
-
-    public function isPrimaryKeyFromMetadata(): bool
-    {
-        return $this->primaryKeysDefinition === self::PRIMARY_KEYS_DEFINITION_METADATA;
     }
 
     public function getColumnNamesInOrder(): array

--- a/src/Backend/Synapse/Exception/Assert.php
+++ b/src/Backend/Synapse/Exception/Assert.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Db\ImportExport\Backend\Synapse\Exception;
+
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\ImportOptionsInterface;
+use Keboola\Db\ImportExport\Storage\ABS\SourceFile;
+use Keboola\Db\ImportExport\Storage\DestinationInterface;
+use Keboola\Db\ImportExport\Storage\SourceInterface;
+use Keboola\Db\ImportExport\Storage\Synapse\Table;
+
+final class Assert
+{
+    public static function assertIsSynapseTableDestination(DestinationInterface $destination): void
+    {
+        if (!$destination instanceof Table) {
+            throw new \Exception(sprintf(
+                'Only "%s" is supported as destination "%s" provided.',
+                Table::class,
+                get_class($destination)
+            ));
+        }
+    }
+
+    public static function assertSynapseImportOptions(ImportOptionsInterface $options): void
+    {
+        if (!$options instanceof SynapseImportOptions) {
+            throw new \Exception(sprintf(
+                'Synapse imported expect $options to be instance of "%s", "%s" given.',
+                SynapseImportOptions::class,
+                get_class($options)
+            ));
+        }
+    }
+
+    public static function assertValidSource(SourceInterface $source): void
+    {
+        if ($source instanceof SourceFile
+            && $source->getCsvOptions()->getEnclosure() === ''
+        ) {
+            throw new \Exception(
+                'CSV property FIELDQUOTE|ECLOSURE must be set when using Synapse analytics.'
+            );
+        }
+    }
+}

--- a/src/Backend/Synapse/Exception/Assert.php
+++ b/src/Backend/Synapse/Exception/Assert.php
@@ -4,15 +4,37 @@ declare(strict_types=1);
 
 namespace Keboola\Db\ImportExport\Backend\Synapse\Exception;
 
+use Keboola\Db\ImportExport\Backend\Synapse\DestinationTableOptions;
 use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 use Keboola\Db\ImportExport\ImportOptionsInterface;
 use Keboola\Db\ImportExport\Storage\ABS\SourceFile;
 use Keboola\Db\ImportExport\Storage\DestinationInterface;
 use Keboola\Db\ImportExport\Storage\SourceInterface;
 use Keboola\Db\ImportExport\Storage\Synapse\Table;
+use Keboola\Db\Import\Exception;
 
 final class Assert
 {
+    public static function assertColumns(
+        SourceInterface $source,
+        DestinationTableOptions $destinationTableOptions
+    ): void {
+        if (count($source->getColumnsNames()) === 0) {
+            throw new Exception(
+                'No columns found in CSV file.',
+                Exception::NO_COLUMNS
+            );
+        }
+
+        $moreColumns = array_diff($source->getColumnsNames(), $destinationTableOptions->getColumnNamesInOrder());
+        if (!empty($moreColumns)) {
+            throw new Exception(
+                'Columns doest not match. Non existing columns: ' . implode(', ', $moreColumns),
+                Exception::COLUMNS_COUNT_NOT_MATCH
+            );
+        }
+    }
+
     public static function assertIsSynapseTableDestination(DestinationInterface $destination): void
     {
         if (!$destination instanceof Table) {

--- a/src/Backend/Synapse/Exception/Assert.php
+++ b/src/Backend/Synapse/Exception/Assert.php
@@ -50,7 +50,7 @@ final class Assert
     {
         if (!$options instanceof SynapseImportOptions) {
             throw new \Exception(sprintf(
-                'Synapse imported expect $options to be instance of "%s", "%s" given.',
+                'Synapse importer expect $options to be instance of "%s", "%s" given.',
                 SynapseImportOptions::class,
                 get_class($options)
             ));

--- a/src/Backend/Synapse/Importer.php
+++ b/src/Backend/Synapse/Importer.php
@@ -10,6 +10,7 @@ use Keboola\Db\Import\Result;
 use Keboola\Db\ImportExport\Backend\ImporterInterface;
 use Keboola\Db\ImportExport\Backend\ImportState;
 use Keboola\Db\ImportExport\Backend\Snowflake\Helper\DateTimeHelper;
+use Keboola\Db\ImportExport\Backend\Synapse\Exception\Assert;
 use Keboola\Db\ImportExport\Backend\Synapse\Helper\BackendHelper;
 use Keboola\Db\ImportExport\ImportOptionsInterface;
 use Keboola\Db\ImportExport\Storage;
@@ -54,22 +55,9 @@ class Importer implements ImporterInterface
         ImportOptionsInterface $options
     ): Result {
         $adapter = $this->getAdapter($source, $destination);
-
-        if (!$options instanceof SynapseImportOptions) {
-            throw new \Exception(sprintf(
-                'Synapse imported expect $options to be instance of "%s", "%s" given.',
-                SynapseImportOptions::class,
-                get_class($options)
-            ));
-        }
-
-        if ($source instanceof Storage\ABS\SourceFile
-            && $source->getCsvOptions()->getEnclosure() === ''
-        ) {
-            throw new \Exception(
-                'CSV property FIELDQUOTE|ECLOSURE must be set when using Synapse analytics.'
-            );
-        }
+        Assert::assertSynapseImportOptions($options);
+        Assert::assertIsSynapseTableDestination($destination);
+        Assert::assertValidSource($source);
 
         $this->importState = new ImportState(BackendHelper::generateTempTableName());
         $this->validateColumns($source, $destination);

--- a/src/Backend/Synapse/Importer.php
+++ b/src/Backend/Synapse/Importer.php
@@ -16,8 +16,6 @@ use Keboola\Db\ImportExport\Storage;
 
 class Importer implements ImporterInterface
 {
-    public const TIMESTAMP_COLUMN_NAME = '_timestamp';
-
     public const DEFAULT_ADAPTERS = [
         Storage\ABS\SynapseImportAdapter::class,
         Storage\Synapse\SynapseImportAdapter::class,

--- a/src/Backend/Synapse/SqlCommandBuilder.php
+++ b/src/Backend/Synapse/SqlCommandBuilder.php
@@ -282,39 +282,12 @@ class SqlCommandBuilder
         );
     }
 
-    public function getTableColumns(string $schemaName, string $tableName): array
-    {
-        /** @var string|false $objectId */
-        $objectId = $this->connection->fetchColumn(
-            $this->getTableObjectIdCommand($schemaName, $tableName)
-        );
-
-        if ($objectId === false) {
-            throw new Exception(sprintf('Table %s.%s does not exist.', $schemaName, $tableName));
-        }
-
-        $result = $this->connection->fetchAll(
-            $this->getTableColumnsCommand($objectId)
-        );
-        return array_map(static function ($column) {
-            return $column['NAME'];
-        }, $result);
-    }
-
     public function getTableObjectIdCommand(string $schemaName, string $tableName): string
     {
         return sprintf(
             'SELECT [object_id] FROM sys.tables WHERE schema_name(schema_id) = %s AND NAME = %s',
             $this->connection->quote($schemaName),
             $this->connection->quote($tableName)
-        );
-    }
-
-    public function getTableColumnsCommand(string $tableObjectId): string
-    {
-        return sprintf(
-            'SELECT [NAME] FROM sys.all_columns WHERE object_id = %s',
-            $this->connection->quote($tableObjectId)
         );
     }
 

--- a/src/Backend/Synapse/SynapseImportOptions.php
+++ b/src/Backend/Synapse/SynapseImportOptions.php
@@ -16,11 +16,17 @@ class SynapseImportOptions extends ImportOptions
     public const TEMP_TABLE_COLUMNSTORE = 'COLUMNSTORE';
     public const TEMP_TABLE_CLUSTERED_INDEX = 'CLUSTERED_INDEX';
 
+    public const DEDUP_TYPE_CTAS = 'CTAS';
+    public const DEDUP_TYPE_TMP_TABLE = 'TMP_TABLE';
+
     /** @var string */
     private $importCredentialsType;
 
     /** @var string */
     private $tempTableType;
+
+    /** @var string */
+    private $dedupType;
 
     public function __construct(
         array $convertEmptyValuesToNull = [],
@@ -28,7 +34,8 @@ class SynapseImportOptions extends ImportOptions
         bool $useTimestamp = false,
         int $numberOfIgnoredLines = 0,
         string $importCredentialsType = self::CREDENTIALS_SAS,
-        string $tempTableType = self::TEMP_TABLE_HEAP
+        string $tempTableType = self::TEMP_TABLE_HEAP,
+        string $dedupType = self::DEDUP_TYPE_TMP_TABLE
     ) {
         parent::__construct(
             $convertEmptyValuesToNull,
@@ -38,6 +45,7 @@ class SynapseImportOptions extends ImportOptions
         );
         $this->importCredentialsType = $importCredentialsType;
         $this->tempTableType = $tempTableType;
+        $this->dedupType = $dedupType;
     }
 
     public function getImportCredentialsType(): string
@@ -48,5 +56,10 @@ class SynapseImportOptions extends ImportOptions
     public function getTempTableType(): string
     {
         return $this->tempTableType;
+    }
+
+    public function useOptimizedDedup(): bool
+    {
+        return $this->dedupType === self::DEDUP_TYPE_CTAS;
     }
 }

--- a/src/Storage/ABS/SourceFile.php
+++ b/src/Storage/ABS/SourceFile.php
@@ -23,6 +23,9 @@ class SourceFile extends BaseFile implements SourceInterface
     /** @var string[] */
     private $columnsNames;
 
+    /** @var string[]|null */
+    private $primaryKeysNames;
+
     public function __construct(
         string $container,
         string $filePath,
@@ -30,12 +33,14 @@ class SourceFile extends BaseFile implements SourceInterface
         string $accountName,
         CsvOptions $csvOptions,
         bool $isSliced,
-        array $columnsNames = []
+        array $columnsNames = [],
+        ?array $primaryKeysNames = null
     ) {
         parent::__construct($container, $filePath, $sasToken, $accountName);
         $this->isSliced = $isSliced;
         $this->csvOptions = $csvOptions;
         $this->columnsNames = $columnsNames;
+        $this->primaryKeysNames = $primaryKeysNames;
     }
 
     /**
@@ -123,5 +128,13 @@ class SourceFile extends BaseFile implements SourceInterface
                     return str_replace('azure://', 'https://', $entryUrl);
             }
         }, $entries);
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getPrimaryKeysNames(): ?array
+    {
+        return $this->primaryKeysNames;
     }
 }

--- a/src/Storage/Snowflake/SelectSource.php
+++ b/src/Storage/Snowflake/SelectSource.php
@@ -18,17 +18,28 @@ class SelectSource implements SourceInterface, SqlSourceInterface
     /** @var string[] */
     private $columnsNames;
 
+    /** @var string[]|null */
+    private $primaryKeysNames;
+
     /**
      * @param string[] $columnsNames
+     * @param string[]|null $primaryKeysNames
      */
     public function __construct(
         string $query,
         array $queryBindings = [],
-        array $columnsNames = []
+        array $columnsNames = [],
+        ?array $primaryKeysNames = null
     ) {
         $this->query = $query;
         $this->queryBindings = $queryBindings;
         $this->columnsNames = $columnsNames;
+        $this->primaryKeysNames = $primaryKeysNames;
+    }
+
+    public function getColumnsNames(): array
+    {
+        return $this->columnsNames;
     }
 
     public function getFromStatement(): string
@@ -41,13 +52,13 @@ class SelectSource implements SourceInterface, SqlSourceInterface
         return $this->query;
     }
 
+    public function getPrimaryKeysNames(): ?array
+    {
+        return $this->primaryKeysNames;
+    }
+
     public function getQueryBindings(): array
     {
         return $this->queryBindings;
-    }
-
-    public function getColumnsNames(): array
-    {
-        return $this->columnsNames;
     }
 }

--- a/src/Storage/Snowflake/Table.php
+++ b/src/Storage/Snowflake/Table.php
@@ -20,14 +20,23 @@ class Table implements SourceInterface, DestinationInterface, SqlSourceInterface
     /** @var string[] */
     private $columnsNames;
 
+    /** @var string[]|null */
+    private $primaryKeysNames;
+
     /**
      * @param string[] $columnsNames
+     * @param string[]|null $primaryKeysNames
      */
-    public function __construct(string $schema, string $tableName, array $columnsNames = [])
-    {
+    public function __construct(
+        string $schema,
+        string $tableName,
+        array $columnsNames = [],
+        ?array $primaryKeysNames = null
+    ) {
         $this->schema = $schema;
         $this->tableName = $tableName;
         $this->columnsNames = $columnsNames;
+        $this->primaryKeysNames = $primaryKeysNames;
     }
 
     public function getFromStatement(): string
@@ -67,6 +76,16 @@ class Table implements SourceInterface, DestinationInterface, SqlSourceInterface
         return $this->tableName;
     }
 
+    public function getPrimaryKeysNames(): ?array
+    {
+        return $this->primaryKeysNames;
+    }
+
+    public function getQueryBindings(): array
+    {
+        return [];
+    }
+
     public function getQuotedTableWithScheme(): string
     {
         return sprintf(
@@ -74,10 +93,5 @@ class Table implements SourceInterface, DestinationInterface, SqlSourceInterface
             QuoteHelper::quoteIdentifier($this->schema),
             QuoteHelper::quoteIdentifier($this->tableName)
         );
-    }
-
-    public function getQueryBindings(): array
-    {
-        return [];
     }
 }

--- a/src/Storage/SourceInterface.php
+++ b/src/Storage/SourceInterface.php
@@ -10,4 +10,11 @@ interface SourceInterface
      * @return string[]
      */
     public function getColumnsNames(): array;
+
+    /**
+     * null means that primary keys are not known
+     *
+     * @return string[]|null
+     */
+    public function getPrimaryKeysNames(): ?array;
 }

--- a/src/Storage/Synapse/SelectSource.php
+++ b/src/Storage/Synapse/SelectSource.php
@@ -21,19 +21,35 @@ class SelectSource implements SourceInterface, SqlSourceInterface
     /** @var string[] */
     private $columnsNames;
 
+    /** @var string[]|null */
+    private $primaryKeysNames;
+
     /**
      * @param string[] $columnsNames
+     * @param string[]|null $primaryKeysNames
      */
     public function __construct(
         string $query,
         array $queryBindings = [],
         array $dataTypes = [],
-        array $columnsNames = []
+        array $columnsNames = [],
+        ?array $primaryKeysNames = null
     ) {
         $this->query = $query;
         $this->queryBindings = $queryBindings;
         $this->dataTypes = $dataTypes;
         $this->columnsNames = $columnsNames;
+        $this->primaryKeysNames = $primaryKeysNames;
+    }
+
+    public function getColumnsNames(): array
+    {
+        return $this->columnsNames;
+    }
+
+    public function getDataTypes(): array
+    {
+        return $this->dataTypes;
     }
 
     public function getFromStatement(): string
@@ -46,18 +62,13 @@ class SelectSource implements SourceInterface, SqlSourceInterface
         return $this->query;
     }
 
+    public function getPrimaryKeysNames(): ?array
+    {
+        return $this->primaryKeysNames;
+    }
+
     public function getQueryBindings(): array
     {
         return $this->queryBindings;
-    }
-
-    public function getDataTypes(): array
-    {
-        return $this->dataTypes;
-    }
-
-    public function getColumnsNames(): array
-    {
-        return $this->columnsNames;
     }
 }

--- a/src/Storage/Synapse/Table.php
+++ b/src/Storage/Synapse/Table.php
@@ -23,15 +23,24 @@ class Table implements SourceInterface, DestinationInterface, SqlSourceInterface
     /** @var string[] */
     private $columnsNames;
 
+    /** @var string[]|null */
+    private $primaryKeysNames;
+
     /**
      * @param string[] $columns
+     * @param string[]|null $primaryKeysNames
      */
-    public function __construct(string $schema, string $tableName, array $columns = [])
-    {
+    public function __construct(
+        string $schema,
+        string $tableName,
+        array $columns = [],
+        ?array $primaryKeysNames = null
+    ) {
         $this->schema = $schema;
         $this->tableName = $tableName;
         $this->platform = new SQLServerPlatform();
         $this->columnsNames = $columns;
+        $this->primaryKeysNames = $primaryKeysNames;
     }
 
     public function getFromStatement(): string
@@ -65,6 +74,16 @@ class Table implements SourceInterface, DestinationInterface, SqlSourceInterface
         );
     }
 
+    public function getPrimaryKeysNames(): ?array
+    {
+        return $this->primaryKeysNames;
+    }
+
+    public function getQueryBindings(): array
+    {
+        return [];
+    }
+
     public function getSchema(): string
     {
         return $this->schema;
@@ -73,10 +92,5 @@ class Table implements SourceInterface, DestinationInterface, SqlSourceInterface
     public function getTableName(): string
     {
         return $this->tableName;
-    }
-
-    public function getQueryBindings(): array
-    {
-        return [];
     }
 }

--- a/tests/ABSSourceTrait.php
+++ b/tests/ABSSourceTrait.php
@@ -44,14 +44,16 @@ trait ABSSourceTrait
         string $filePath,
         array $columns = [],
         bool $isSliced = false,
-        bool $isDirectory = false
+        bool $isDirectory = false,
+        ?array $primaryKeys = null
     ): Storage\ABS\SourceFile {
         return $this->createABSSourceInstanceFromCsv(
             $filePath,
             new CsvOptions(),
             $columns,
             $isSliced,
-            $isDirectory
+            $isDirectory,
+            $primaryKeys
         );
     }
 
@@ -60,7 +62,8 @@ trait ABSSourceTrait
         CsvOptions $options,
         array $columns = [],
         bool $isSliced = false,
-        bool $isDirectory = false
+        bool $isDirectory = false,
+        ?array $primaryKeys = null
     ): Storage\ABS\SourceFile {
         if ($isDirectory) {
             $class = Storage\ABS\SourceDirectory::class;
@@ -74,7 +77,8 @@ trait ABSSourceTrait
             (string) getenv('ABS_ACCOUNT_NAME'),
             $options,
             $isSliced,
-            $columns
+            $columns,
+            $primaryKeys
         );
     }
 

--- a/tests/functional/Synapse/SqlCommandBuilderTest.php
+++ b/tests/functional/Synapse/SqlCommandBuilderTest.php
@@ -565,46 +565,6 @@ EOT
         $this->assertNotFalse($expectedFalse);
     }
 
-    public function testGetTableColumns(): void
-    {
-        $this->createTestSchema();
-        $this->createTestTableWithColumns();
-
-        $response = $this->qb->getTableColumns(self::TEST_SCHEMA, self::TEST_TABLE);
-
-        $this->assertCount(3, $response);
-        $this->assertEqualsCanonicalizing(['id', 'col1', 'col2'], $response);
-    }
-
-    public function testGetTableColumnsCommand(): void
-    {
-        $this->createTestSchema();
-        $this->createTestTableWithColumns();
-
-        /** @var string $tableId */
-        $tableId = $this->connection->fetchColumn(
-            $this->qb->getTableObjectIdCommand(self::TEST_SCHEMA, self::TEST_TABLE)
-        );
-
-        $sql = $this->qb->getTableColumnsCommand($tableId);
-        $this->assertStringStartsWith(
-            'SELECT [NAME] FROM sys.all_columns WHERE object_id = \'',
-            $sql
-        );
-
-        $response = $this->connection->fetchAll($sql);
-
-        $this->assertCount(3, $response);
-        $this->assertEqualsCanonicalizing(
-            [
-                ['name' => 'id'],
-                ['name' => 'col1'],
-                ['name' => 'col2'],
-            ],
-            $response
-        );
-    }
-
     public function testGetTableItemsCountCommand(): void
     {
         $this->createTestSchema();

--- a/tests/functional/Synapse/SqlCommandBuilderTest.php
+++ b/tests/functional/Synapse/SqlCommandBuilderTest.php
@@ -236,6 +236,11 @@ class SqlCommandBuilderTest extends SynapseBaseTestCase
             {
                 return ['col1', 'col2'];
             }
+
+            public function getPrimaryKeysNames(): ?array
+            {
+                return [];
+            }
         };
     }
 

--- a/tests/functional/Synapse/SynapseBaseTestCase.php
+++ b/tests/functional/Synapse/SynapseBaseTestCase.php
@@ -12,6 +12,7 @@ use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\SourceInterface;
 use Keboola\Db\ImportExport\Storage\Synapse\Table;
 use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
+use Keboola\TableBackendUtils\Table\SynapseTableReflection;
 use Tests\Keboola\Db\ImportExportFunctional\ImportExportBaseTest;
 
 class SynapseBaseTestCase extends ImportExportBaseTest
@@ -300,7 +301,11 @@ EOT
         $sortKey,
         string $message = 'Imported tables are not the same as expected'
     ): void {
-        $tableColumns = $this->qb->getTableColumns($table->getSchema(), $table->getTableName());
+        $tableColumns = (new SynapseTableReflection(
+            $this->connection,
+            $table->getSchema(),
+            $table->getTableName()
+        ))->getColumnsNames();
 
         if ($options->useTimestamp()) {
             $this->assertContains('_timestamp', $tableColumns);

--- a/tests/unit/Backend/Snowflake/SqlCommandBuilderTest.php
+++ b/tests/unit/Backend/Snowflake/SqlCommandBuilderTest.php
@@ -69,6 +69,11 @@ class SqlCommandBuilderTest extends TestCase
             {
                 return ['col1', 'col2'];
             }
+
+            public function getPrimaryKeysNames(): ?array
+            {
+                return [];
+            }
         };
     }
 

--- a/tests/unit/Backend/Synapse/AssertTest.php
+++ b/tests/unit/Backend/Synapse/AssertTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\Db\ImportExportUnit\Backend\Synapse;
+
+use Keboola\Db\ImportExport\Backend\Synapse\DestinationTableOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\Exception\Assert;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\ImportOptions;
+use Keboola\Db\ImportExport\Storage\ABS\DestinationFile;
+use Keboola\Db\ImportExport\Storage\SourceInterface;
+use Keboola\Db\ImportExport\Storage\Synapse\Table;
+use PHPUnit\Framework\TestCase;
+use Keboola\Db\Import\Exception;
+
+class AssertTest extends TestCase
+{
+    public function testAssertColumnsPass(): void
+    {
+        $this->expectNotToPerformAssertions();
+        Assert::assertColumns(
+            new class implements SourceInterface {
+                public function getColumnsNames(): array
+                {
+                    return ['name', 'id'];
+                }
+
+                public function getPrimaryKeysNames(): ?array
+                {
+                    return null;
+                }
+            },
+            new DestinationTableOptions(
+                ['id', 'name'],
+                [],
+                DestinationTableOptions::PRIMARY_KEYS_DEFINITION_METADATA
+            )
+        );
+    }
+
+    public function testAssertNoColumnsFail(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No columns found in CSV file.');
+        Assert::assertColumns(
+            new class implements SourceInterface {
+                public function getColumnsNames(): array
+                {
+                    return [];
+                }
+
+                public function getPrimaryKeysNames(): ?array
+                {
+                    return null;
+                }
+            },
+            new DestinationTableOptions(
+                ['id', 'name'],
+                [],
+                DestinationTableOptions::PRIMARY_KEYS_DEFINITION_METADATA
+            )
+        );
+    }
+
+    public function testAssertColumnsNotMatch(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Columns doest not match. Non existing columns: unexpected');
+        Assert::assertColumns(
+            new class implements SourceInterface {
+                public function getColumnsNames(): array
+                {
+                    return ['name', 'id', 'unexpected'];
+                }
+
+                public function getPrimaryKeysNames(): ?array
+                {
+                    return null;
+                }
+            },
+            new DestinationTableOptions(
+                ['id', 'name'],
+                [],
+                DestinationTableOptions::PRIMARY_KEYS_DEFINITION_METADATA
+            )
+        );
+    }
+
+    public function testAssertIsSynapseTableDestinationPass(): void
+    {
+        $this->expectNotToPerformAssertions();
+        Assert::assertIsSynapseTableDestination(new Table('', ''));
+    }
+
+    public function testAssertIsSynapseTableDestinationNoTable(): void
+    {
+        $this->expectException(\Throwable::class);
+        $this->expectExceptionMessage(
+        // phpcs:ignore
+            'Only "Keboola\Db\ImportExport\Storage\Synapse\Table" is supported as destination "Keboola\Db\ImportExport\Storage\ABS\DestinationFile" provided.'
+        );
+        Assert::assertIsSynapseTableDestination(new DestinationFile('', '', '', ''));
+    }
+
+    public function testAssertSynapseImportOptions(): void
+    {
+        $this->expectNotToPerformAssertions();
+        Assert::assertSynapseImportOptions(new SynapseImportOptions());
+    }
+
+    public function testAssertValidSource(): void
+    {
+        $this->expectException(\Throwable::class);
+        $this->expectExceptionMessage(
+        // phpcs:ignore
+            'Synapse importer expect $options to be instance of "Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions", "Keboola\Db\ImportExport\ImportOptions" given.'
+        );
+        Assert::assertSynapseImportOptions(new ImportOptions());
+    }
+}

--- a/tests/unit/Backend/Synapse/AssertTest.php
+++ b/tests/unit/Backend/Synapse/AssertTest.php
@@ -33,8 +33,7 @@ class AssertTest extends TestCase
             },
             new DestinationTableOptions(
                 ['id', 'name'],
-                [],
-                DestinationTableOptions::PRIMARY_KEYS_DEFINITION_METADATA
+                []
             )
         );
     }
@@ -57,8 +56,7 @@ class AssertTest extends TestCase
             },
             new DestinationTableOptions(
                 ['id', 'name'],
-                [],
-                DestinationTableOptions::PRIMARY_KEYS_DEFINITION_METADATA
+                []
             )
         );
     }
@@ -81,8 +79,7 @@ class AssertTest extends TestCase
             },
             new DestinationTableOptions(
                 ['id', 'name'],
-                [],
-                DestinationTableOptions::PRIMARY_KEYS_DEFINITION_METADATA
+                []
             )
         );
     }

--- a/tests/unit/Backend/Synapse/AssertTest.php
+++ b/tests/unit/Backend/Synapse/AssertTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Keboola\Db\ImportExportUnit\Backend\Synapse;
 
+use Keboola\CsvOptions\CsvOptions;
 use Keboola\Db\ImportExport\Backend\Synapse\DestinationTableOptions;
 use Keboola\Db\ImportExport\Backend\Synapse\Exception\Assert;
 use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
 use Keboola\Db\ImportExport\ImportOptions;
 use Keboola\Db\ImportExport\Storage\ABS\DestinationFile;
+use Keboola\Db\ImportExport\Storage\ABS\SourceFile;
 use Keboola\Db\ImportExport\Storage\SourceInterface;
 use Keboola\Db\ImportExport\Storage\Synapse\Table;
 use PHPUnit\Framework\TestCase;
@@ -100,13 +102,13 @@ class AssertTest extends TestCase
         Assert::assertIsSynapseTableDestination(new DestinationFile('', '', '', ''));
     }
 
-    public function testAssertSynapseImportOptions(): void
+    public function testAssertSynapseImportOptionsPass(): void
     {
         $this->expectNotToPerformAssertions();
         Assert::assertSynapseImportOptions(new SynapseImportOptions());
     }
 
-    public function testAssertValidSource(): void
+    public function testAssertSynapseImportOptionsFail(): void
     {
         $this->expectException(\Throwable::class);
         $this->expectExceptionMessage(
@@ -114,5 +116,42 @@ class AssertTest extends TestCase
             'Synapse importer expect $options to be instance of "Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions", "Keboola\Db\ImportExport\ImportOptions" given.'
         );
         Assert::assertSynapseImportOptions(new ImportOptions());
+    }
+
+    public function testAssertValidSourcePass(): void
+    {
+        $this->expectNotToPerformAssertions();
+        Assert::assertValidSource(new SourceFile(
+            '',
+            '',
+            '',
+            '',
+            new CsvOptions(),
+            false
+        ));
+        Assert::assertValidSource(new Table(
+            '',
+            ''
+        ));
+    }
+
+    public function testAssertValidSourceFail(): void
+    {
+        $this->expectException(\Throwable::class);
+        $this->expectExceptionMessage(
+        // phpcs:ignore
+            'CSV property FIELDQUOTE|ECLOSURE must be set when using Synapse analytics.'
+        );
+        Assert::assertValidSource(new SourceFile(
+            '',
+            '',
+            '',
+            '',
+            new CsvOptions(
+                CsvOptions::DEFAULT_DELIMITER,
+                ''
+            ),
+            false
+        ));
     }
 }

--- a/tests/unit/Backend/Synapse/DestinationTableOptionsTest.php
+++ b/tests/unit/Backend/Synapse/DestinationTableOptionsTest.php
@@ -13,11 +13,9 @@ class DestinationTableOptionsTest extends TestCase
     {
         $options = new DestinationTableOptions(
             ['pk1', 'pk1', 'col1', 'col2'],
-            ['pk1', 'pk1'],
-            DestinationTableOptions::PRIMARY_KEYS_DEFINITION_METADATA
+            ['pk1', 'pk1']
         );
         self::assertEquals(['pk1', 'pk1', 'col1', 'col2'], $options->getColumnNamesInOrder());
         self::assertEquals(['pk1', 'pk1'], $options->getPrimaryKeys());
-        self::assertTrue($options->isPrimaryKeyFromMetadata());
     }
 }

--- a/tests/unit/Backend/Synapse/DestinationTableOptionsTest.php
+++ b/tests/unit/Backend/Synapse/DestinationTableOptionsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\Db\ImportExportUnit\Backend\Synapse;
+
+use Keboola\Db\ImportExport\Backend\Synapse\DestinationTableOptions;
+use PHPUnit\Framework\TestCase;
+
+class DestinationTableOptionsTest extends TestCase
+{
+    public function testDefaultValues(): void
+    {
+        $options = new DestinationTableOptions(
+            ['pk1', 'pk1', 'col1', 'col2'],
+            ['pk1', 'pk1'],
+            DestinationTableOptions::PRIMARY_KEYS_DEFINITION_METADATA
+        );
+        self::assertEquals(['pk1', 'pk1', 'col1', 'col2'], $options->getColumnNamesInOrder());
+        self::assertEquals(['pk1', 'pk1'], $options->getPrimaryKeys());
+        self::assertTrue($options->isPrimaryKeyFromMetadata());
+    }
+}

--- a/tests/unit/Backend/Synapse/SynapseImportOptionsTest.php
+++ b/tests/unit/Backend/Synapse/SynapseImportOptionsTest.php
@@ -18,6 +18,7 @@ class SynapseImportOptionsTest extends TestCase
         self::assertFalse($options->useTimestamp());
         self::assertEquals(0, $options->getNumberOfIgnoredLines());
         self::assertEquals('SAS', $options->getImportCredentialsType());
+        self::assertEquals(false, $options->useOptimizedDedup());
     }
 
     public function testValues(): void
@@ -27,12 +28,19 @@ class SynapseImportOptionsTest extends TestCase
             true,
             true,
             SynapseImportOptions::SKIP_FIRST_LINE,
-            SynapseImportOptions::CREDENTIALS_MANAGED_IDENTITY
+            SynapseImportOptions::CREDENTIALS_MANAGED_IDENTITY,
+            SynapseImportOptions::TEMP_TABLE_CLUSTERED_INDEX,
+            SynapseImportOptions::DEDUP_TYPE_CTAS
         );
 
         self::assertSame(['col1'], $options->getConvertEmptyValuesToNull());
         self::assertTrue($options->isIncremental());
         self::assertTrue($options->useTimestamp());
+        self::assertTrue($options->useOptimizedDedup());
+        self::assertEquals(
+            SynapseImportOptions::TEMP_TABLE_CLUSTERED_INDEX,
+            $options->getTempTableType()
+        );
         self::assertEquals(1, $options->getNumberOfIgnoredLines());
         self::assertEquals('MANAGED_IDENTITY', $options->getImportCredentialsType());
     }

--- a/tests/unit/Storage/ABS/SourceFileTest.php
+++ b/tests/unit/Storage/ABS/SourceFileTest.php
@@ -20,6 +20,7 @@ class SourceFileTest extends BaseTestCase
         self::assertInstanceOf(Storage\SourceInterface::class, $source);
         self::assertEquals('file.csv', $source->getFilePath());
         self::assertEquals([], $source->getColumnsNames());
+        self::assertNull($source->getPrimaryKeysNames());
     }
 
     public function testGetManifestEntries(): void

--- a/tests/unit/Storage/Snowflake/SelectSourceTest.php
+++ b/tests/unit/Storage/Snowflake/SelectSourceTest.php
@@ -17,5 +17,6 @@ class SelectSourceTest extends TestCase
         $this->assertEquals('SELECT * FROM "SCHEMA"."TABLE"', $source->getQuery());
         $this->assertSame(['prop' => 1], $source->getQueryBindings());
         $this->assertSame(['col1'], $source->getColumnsNames());
+        $this->assertNull($source->getPrimaryKeysNames());
     }
 }

--- a/tests/unit/Storage/Snowflake/TableTest.php
+++ b/tests/unit/Storage/Snowflake/TableTest.php
@@ -26,6 +26,7 @@ class TableTest extends TestCase
         self::assertEquals([], $source->getQueryBindings());
         self::assertEquals([], $source->getColumnsNames());
         self::assertEquals('SELECT * FROM "schema"."table"', $source->getFromStatement());
+        self::assertNull($source->getPrimaryKeysNames());
     }
 
     public function testColumns(): void

--- a/tests/unit/Storage/Synapse/SelectSourceTest.php
+++ b/tests/unit/Storage/Synapse/SelectSourceTest.php
@@ -18,5 +18,6 @@ class SelectSourceTest extends TestCase
         $this->assertSame(['prop' => 1], $source->getQueryBindings());
         $this->assertSame([], $source->getDataTypes());
         $this->assertSame(['col1'], $source->getColumnsNames());
+        $this->assertNull($source->getPrimaryKeysNames());
     }
 }

--- a/tests/unit/Storage/Synapse/TableTest.php
+++ b/tests/unit/Storage/Synapse/TableTest.php
@@ -25,6 +25,7 @@ class TableTest extends TestCase
         self::assertEquals([], $source->getQueryBindings());
         self::assertEquals([], $source->getColumnsNames());
         self::assertEquals('SELECT * FROM [schema].[table]', $source->getFromStatement());
+        self::assertNull($source->getPrimaryKeysNames());
     }
 
     public function testColumns(): void


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/KBC-1251

Primární a nejdůležitější změna je, že pro optimalizovaný full import bude potřeba předávat PK z venku a nepoužívat zjišťování z tabulky. K tomu sem pročistil synapse Importer, aby byl přehlednější. 

Jde to po commitech:
- TIMESTAMP_COLUMN_NAME constantu sem přesunul do interface 
- přidání table utils jako závislost
- nová třída Assert abych odlehčil importer
- nová třída DestinationTableOptions - je potřeba si držet primární klíče a sloupce v pořadí pro cílovou tabulku, protože se všechno při optimalizovaném importu smaže a vytvoří znova
- do Assertu sem hodil aj porovnávání sloupců a použil sem SynapseTableReflection
- upravil sem testy aby šlo přidávat PK

_pozn. pro erika: Hodně změněných souborů je protože jsem přidal metodu do SourceInterface a ta má 5 implementací + další v testech jako anonymní třídy a každá implentace má testy, to sa naskládá :D_