### PR TITLE
KBC-1270 use suffix for synapse server name in CI

### DIFF
--- a/provisioning/src/DeploySynapse.php
+++ b/provisioning/src/DeploySynapse.php
@@ -55,7 +55,8 @@ final class DeploySynapse extends BaseCmd
         $this->assertOption(self::OPTION_ABS_ACCOUNT_NAME, $absAccountName);
 
         $serverPassword = $this->runCmdSingleLineOutput('openssl rand -base64 32');
-        $deploymentName = sprintf('%s_%s', $serverName, $this->runCmdSingleLineOutput('openssl rand -hex 5'));
+        $suffix = $this->runCmdSingleLineOutput('openssl rand -hex 5');
+        $deploymentName = sprintf('%s_%s', $serverName, $suffix);
 
         $output->writeln([
             'Start Synapse server deploy',
@@ -70,6 +71,7 @@ az group deployment create \
     administratorLogin=keboola \
     administratorPassword=$serverPassword \
     warehouseName=$serverName \
+    suffix=$suffix \
     warehouseCapacity=900
 EOT
         );

--- a/provisioning/synapse/synapse.json
+++ b/provisioning/synapse/synapse.json
@@ -2,6 +2,9 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "suffix": {
+            "type": "string"
+        },
         "administratorLogin": {
             "type": "string"
         },
@@ -16,8 +19,8 @@
         }
     },
     "variables": {
-        "sqlServerName": "[concat(parameters('warehouseName'), '-sql-', uniqueString(resourceGroup().id))]",
-        "warehouseName": "[concat(parameters('warehouseName'), '-db-', uniqueString(resourceGroup().id))]"
+        "sqlServerName": "[concat(parameters('warehouseName'), '-sql-', uniqueString(resourceGroup().id), parameters('suffix'))]",
+        "warehouseName": "[concat(parameters('warehouseName'), '-db-', uniqueString(resourceGroup().id), parameters('suffix'))]"
     },
     "resources": [
         {


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/KBC-1270
V azure padá deployment kvůlu nějakému kixu. viz. ticket 121020125002402

Tady to opravuje ten problém tak, že přidává unikátní suffix k resources.