### PR TITLE
KBC-1005 detect line ending in synapse import

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "doctrine/dbal": "^2.9",
         "keboola/csv-options": "^1",
         "keboola/php-csv-db-import": "^5.0",
-        "keboola/php-file-storage-utils": "^0.1.0",
+        "keboola/php-file-storage-utils": "^0.2",
         "keboola/table-backend-utils": "^0.6.0",
         "microsoft/azure-storage-blob": "^1.4"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -231,11 +231,6 @@ parameters:
 			path: src/Storage/ABS/SnowflakeImportAdapter.php
 
 		-
-			message: "#^Method Keboola\\\\Db\\\\ImportExport\\\\Storage\\\\ABS\\\\SourceDirectory\\:\\:getManifestEntries\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Storage/ABS/SourceDirectory.php
-
-		-
 			message: "#^Method Keboola\\\\Db\\\\ImportExport\\\\Storage\\\\ABS\\\\SourceFile\\:\\:__construct\\(\\) has parameter \\$columnsNames with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Storage/ABS/SourceFile.php

--- a/src/Storage/ABS/SourceDirectory.php
+++ b/src/Storage/ABS/SourceDirectory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\Db\ImportExport\Storage\ABS;
 
+use Keboola\Db\ImportExport\Storage\FileNotFoundException;
 use Keboola\FileStorage\Abs\AbsProvider;
 use Keboola\FileStorage\Abs\LineEnding\LineEndingDetector;
 use Keboola\FileStorage\LineEnding\StringLineEndingDetectorHelper;
@@ -32,7 +33,11 @@ class SourceDirectory extends SourceFile
             $this->getBlobPath($blob->getUrl())
         );
 
-        return $detector->getLineEnding($file);
+        try {
+            return $detector->getLineEnding($file);
+        } catch (\Keboola\FileStorage\FileNotFoundException $e) {
+            throw FileNotFoundException::createFromFileNotFoundException($e);
+        }
     }
 
     private function getEntriesInFolder(BlobRestProxy $blobClient): BlobIterator

--- a/src/Storage/ABS/SourceFile.php
+++ b/src/Storage/ABS/SourceFile.php
@@ -47,7 +47,7 @@ class SourceFile extends BaseFile implements SourceInterface
         $this->primaryKeysNames = $primaryKeysNames;
     }
 
-    private function getBlobPath(string $entryUrl): string
+    protected function getBlobPath(string $entryUrl): string
     {
         return explode(sprintf('blob.core.windows.net/%s/', $this->container), $entryUrl)[1];
     }
@@ -170,6 +170,9 @@ class SourceFile extends BaseFile implements SourceInterface
             $file = RelativePath::createFromRootAndPath(new AbsProvider(), $this->container, $this->filePath);
         } else {
             $manifest = $this->downloadAndParseManifest($client);
+            if (count($manifest['entries']) === 0) {
+                return StringLineEndingDetectorHelper::EOL_UNIX;
+            }
             $blobPath = $this->getBlobPath($manifest['entries'][0]['url']);
             $file = RelativePath::createFromRootAndPath(new AbsProvider(), $this->container, $blobPath);
         }

--- a/src/Storage/ABS/SynapseImportAdapter.php
+++ b/src/Storage/ABS/SynapseImportAdapter.php
@@ -11,6 +11,7 @@ use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportAdapterInterface;
 use Keboola\Db\ImportExport\ImportOptionsInterface;
 use Keboola\Db\ImportExport\Storage;
 use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
+use Keboola\FileStorage\LineEnding\StringLineEndingDetectorHelper;
 
 class SynapseImportAdapter implements SynapseImportAdapterInterface
 {
@@ -91,6 +92,11 @@ class SynapseImportAdapter implements SynapseImportAdapterInterface
                 ));
         }
 
+        $rowTerminator = '';
+        if ($source->getLineEnding() === StringLineEndingDetectorHelper::EOL_UNIX) {
+            $rowTerminator = 'ROWTERMINATOR=\'0x0A\',';
+        }
+
         $fieldDelimiter = $this->connection->quote($source->getCsvOptions()->getDelimiter());
         $firstRow = '';
         if ($importOptions->getNumberOfIgnoredLines() !== 0) {
@@ -119,7 +125,7 @@ WITH (
     FIELDQUOTE=$enclosure,
     FIELDTERMINATOR=$fieldDelimiter,
     ENCODING = 'UTF8',
-    ROWTERMINATOR='0x0A',
+    $rowTerminator
     IDENTITY_INSERT = 'OFF'
     $firstRow
 )

--- a/src/Storage/FileNotFoundException.php
+++ b/src/Storage/FileNotFoundException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Db\ImportExport\Storage;
+
+use Keboola\Db\Import\Exception;
+use MicrosoftAzure\Storage\Common\Exceptions\ServiceException;
+use Throwable;
+
+class FileNotFoundException extends Exception
+{
+    public function __construct(string $message = '', ?Throwable $previous = null)
+    {
+        parent::__construct('Load error: ' . $message, Exception::MANDATORY_FILE_NOT_FOUND, $previous);
+    }
+
+    public static function createFromFileNotFoundException(
+        \Keboola\FileStorage\FileNotFoundException $e
+    ): FileNotFoundException {
+        return new self($e->getMessage(), $e);
+    }
+
+    public static function createFromServiceException(ServiceException $e): FileNotFoundException
+    {
+        return new self($e->getErrorText(), $e);
+    }
+}

--- a/src/Storage/ManifestNotFoundException.php
+++ b/src/Storage/ManifestNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Db\ImportExport\Storage;
+
+use Keboola\Db\Import\Exception;
+use Throwable;
+
+class ManifestNotFoundException extends Exception
+{
+    public function __construct(?Throwable $previous = null)
+    {
+        parent::__construct(
+            'Load error: manifest file was not found.',
+            Exception::MANDATORY_FILE_NOT_FOUND,
+            $previous
+        );
+    }
+}

--- a/tests/data/tw_accounts.crlf.csv
+++ b/tests/data/tw_accounts.crlf.csv
@@ -1,0 +1,4 @@
+id,idTwitter,name,import,isImported,apiLimitExceededDatetime,analyzeSentiment,importKloutScore,timestamp,oauthToken,oauthSecret,idApp
+15,448810375,"KeboolaDev "" with ščř",0,1,,1,0,2012-02-20 09:34:22,"ddd","ddd",1
+18,512024829,"Karel says: ""I'll not let anyone down, including you""",,1,2012-03-19 16:05:32,1,1,2012-03-19 16:05:32,"ddd","ddd",1
+60,22184682988,mr_hashos,1,1,,1,0,2012-03-28 09:27:24,"ddd","ddd",1

--- a/tests/functional/Synapse/FullImportTest.php
+++ b/tests/functional/Synapse/FullImportTest.php
@@ -57,8 +57,6 @@ class FullImportTest extends SynapseBaseTestCase
             $expectedLargeSlicedManifest[] = ['a', 'b'];
         }
 
-        $tests = [];
-
         // full imports
         yield 'large manifest' => [
             $this->createABSSourceInstance(
@@ -171,6 +169,20 @@ class FullImportTest extends SynapseBaseTestCase
         yield 'accounts' => [
             $this->createABSSourceInstance(
                 'tw_accounts.csv',
+                $accountsHeader,
+                false,
+                false,
+                ['id']
+            ),
+            new Storage\Synapse\Table($this->getDestinationSchemaName(), self::TABLE_ACCOUNTS_3),
+            $this->getSynapseImportOptions(),
+            $expectedAccounts,
+            3,
+            [self::TABLE_ACCOUNTS_3],
+        ];
+        yield 'accounts crlf' => [
+            $this->createABSSourceInstance(
+                'tw_accounts.crlf.csv',
                 $accountsHeader,
                 false,
                 false,
@@ -329,8 +341,6 @@ class FullImportTest extends SynapseBaseTestCase
             1,
             [self::TABLE_TYPES],
         ];
-
-        return $tests;
     }
 
     /**

--- a/tests/unit/Storage/ABS/SourceDirectoryTest.php
+++ b/tests/unit/Storage/ABS/SourceDirectoryTest.php
@@ -39,4 +39,16 @@ class SourceDirectoryTest extends BaseTestCase
         $entries = $source->getManifestEntries();
         self::assertCount(2, $entries);
     }
+
+    public function testGetLineEnding(): void
+    {
+        $source = $this->createABSSourceInstanceFromCsv(
+            'sliced_accounts_no_manifest/',
+            new CsvOptions(),
+            [],
+            true,
+            true
+        );
+        self::assertEquals('lf', $source->getLineEnding());
+    }
 }

--- a/tests/unit/Storage/ABS/SourceFileTest.php
+++ b/tests/unit/Storage/ABS/SourceFileTest.php
@@ -67,6 +67,12 @@ class SourceFileTest extends BaseTestCase
         self::assertSame('lf', $source->getLineEnding());
     }
 
+    public function testGetLineEndingSingleCrlf(): void
+    {
+        $source = $this->createABSSourceInstance('tw_accounts.crlf.csv');
+        self::assertSame('crlf', $source->getLineEnding());
+    }
+
     public function testGetLineEndingCompressed(): void
     {
         $source = $this->createABSSourceInstance('04_tw_accounts.csv.gz');

--- a/tests/unit/Storage/ABS/SourceFileTest.php
+++ b/tests/unit/Storage/ABS/SourceFileTest.php
@@ -54,4 +54,22 @@ class SourceFileTest extends BaseTestCase
         $this->expectExceptionCode(Exception::MANDATORY_FILE_NOT_FOUND);
         $source->getManifestEntries();
     }
+
+    public function testGetLineEndingSliced(): void
+    {
+        $source = $this->createABSSourceInstance('sliced/accounts/accounts.csvmanifest', [], true);
+        self::assertSame('lf', $source->getLineEnding());
+    }
+
+    public function testGetLineEndingSingle(): void
+    {
+        $source = $this->createABSSourceInstance('file.csv');
+        self::assertSame('lf', $source->getLineEnding());
+    }
+
+    public function testGetLineEndingCompressed(): void
+    {
+        $source = $this->createABSSourceInstance('04_tw_accounts.csv.gz');
+        self::assertSame('lf', $source->getLineEnding());
+    }
 }

--- a/tests/unit/Storage/ABS/SourceFileTest.php
+++ b/tests/unit/Storage/ABS/SourceFileTest.php
@@ -72,4 +72,10 @@ class SourceFileTest extends BaseTestCase
         $source = $this->createABSSourceInstance('04_tw_accounts.csv.gz');
         self::assertSame('lf', $source->getLineEnding());
     }
+
+    public function testGetLineEndingEmptyManifest(): void
+    {
+        $source = $this->createABSSourceInstance('empty.manifest', [], true);
+        self::assertSame('lf', $source->getLineEnding());
+    }
 }


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/KBC-1005

implementation of: https://github.com/keboola/php-file-storage-utils/pull/4

- SourceFile, SourceDirectory sem trošku refactoroval ať tam nedělám copy paste, oba mají novou metodu `getLineEnding`
- SynapseImportAdapter pak podle `getLineEnding` nastavuje ROWTERMINATOR pro COPY INTO, default se nenastavuje pro CLRF to option nepotřebuje, ale u LF je potřeba nastavit ROWTERMINATOR tak jak byl do teď.