### PR TITLE
KBC-2207 Optimize synapse imports

### DIFF
--- a/src/Backend/Synapse/ToFinalTable/IncrementalImporter.php
+++ b/src/Backend/Synapse/ToFinalTable/IncrementalImporter.php
@@ -99,12 +99,7 @@ final class IncrementalImporter implements ToFinalTableImporterInterface
                     $destinationTableDefinition->getPrimaryKeysNames()
                 )
             );
-            $this->connection->executeStatement(
-                $this->sqlBuilder->getTruncateTableWithDeleteCommand(
-                    $stagingTableDefinition->getSchemaName(),
-                    $stagingTableDefinition->getTableName()
-                )
-            );
+
             $state->stopTimer(self::TIMER_DEDUP_STAGING);
         } else {
             $this->connection->executeStatement(

--- a/src/Backend/Synapse/ToFinalTable/SqlBuilder.php
+++ b/src/Backend/Synapse/ToFinalTable/SqlBuilder.php
@@ -25,7 +25,6 @@ class SqlBuilder
         return 'COMMIT';
     }
 
-
     /**
      * @param string[] $primaryKeys
      */

--- a/src/Backend/Synapse/ToFinalTable/SqlBuilder.php
+++ b/src/Backend/Synapse/ToFinalTable/SqlBuilder.php
@@ -371,8 +371,11 @@ class SqlBuilder
             SynapseQuote::quoteSingleIdentifier($destinationTableDefinition->getTableName())
         );
 
-        $useTimestamp = !in_array(ToStageImporterInterface::TIMESTAMP_COLUMN_NAME, $sourceTableDefinition->getColumnsNames(), true)
-            && $importOptions->useTimestamp();
+        $useTimestamp = !in_array(
+            ToStageImporterInterface::TIMESTAMP_COLUMN_NAME,
+            $sourceTableDefinition->getColumnsNames(),
+            true
+        ) && $importOptions->useTimestamp();
 
         $columnsSetSql = [];
         /** @var SynapseColumn $columnDefinition */
@@ -408,7 +411,11 @@ class SqlBuilder
         }
 
         if ($useTimestamp) {
-            $columnsSetSql[] = sprintf('%s AS %s', SynapseQuote::quote($timestamp), ToStageImporterInterface::TIMESTAMP_COLUMN_NAME);
+            $columnsSetSql[] = sprintf(
+                '%s AS %s',
+                SynapseQuote::quote($timestamp),
+                ToStageImporterInterface::TIMESTAMP_COLUMN_NAME
+            );
         }
 
         $distributionSql = $this->getSqlDistributionPart($destinationTableDefinition);

--- a/src/Backend/Synapse/ToFinalTable/SqlBuilder.php
+++ b/src/Backend/Synapse/ToFinalTable/SqlBuilder.php
@@ -25,6 +25,7 @@ class SqlBuilder
         return 'COMMIT';
     }
 
+
     /**
      * @param string[] $primaryKeys
      */
@@ -352,6 +353,72 @@ class SqlBuilder
             'INSERT INTO %s (%s) (SELECT %s FROM %s.%s AS [src])',
             $destinationTable,
             $this->getColumnsString($insColumns),
+            implode(',', $columnsSetSql),
+            SynapseQuote::quoteSingleIdentifier($sourceTableDefinition->getSchemaName()),
+            SynapseQuote::quoteSingleIdentifier($sourceTableDefinition->getTableName())
+        );
+    }
+
+    public function getCTASInsertAllIntoTargetTableCommand(
+        SynapseTableDefinition $sourceTableDefinition,
+        SynapseTableDefinition $destinationTableDefinition,
+        SynapseImportOptions $importOptions,
+        string $timestamp
+    ): string {
+        $destinationTable = sprintf(
+            '%s.%s',
+            SynapseQuote::quoteSingleIdentifier($destinationTableDefinition->getSchemaName()),
+            SynapseQuote::quoteSingleIdentifier($destinationTableDefinition->getTableName())
+        );
+
+        $useTimestamp = !in_array(ToStageImporterInterface::TIMESTAMP_COLUMN_NAME, $sourceTableDefinition->getColumnsNames(), true)
+            && $importOptions->useTimestamp();
+
+        $columnsSetSql = [];
+        /** @var SynapseColumn $columnDefinition */
+        foreach ($sourceTableDefinition->getColumnsDefinitions() as $columnDefinition) {
+            if (in_array($columnDefinition->getColumnName(), $importOptions->getConvertEmptyValuesToNull(), true)) {
+                // use nullif only for string base type
+                if ($columnDefinition->getColumnDefinition()->getBasetype() === BaseType::STRING) {
+                    $columnsSetSql[] = sprintf(
+                        'NULLIF(%s, \'\') AS %s',
+                        SynapseQuote::quoteSingleIdentifier($columnDefinition->getColumnName()),
+                        SynapseQuote::quoteSingleIdentifier($columnDefinition->getColumnName())
+                    );
+                } else {
+                    $columnsSetSql[] = SynapseQuote::quoteSingleIdentifier($columnDefinition->getColumnName());
+                }
+            } elseif ($columnDefinition->getColumnDefinition()->getBasetype() === BaseType::STRING) {
+                $columnsSetSql[] = sprintf(
+                    'CAST(COALESCE(%s, \'\') as %s) AS %s',
+                    SynapseQuote::quoteSingleIdentifier($columnDefinition->getColumnName()),
+                    $this->getColumnTypeSqlDefinition($columnDefinition),
+                    SynapseQuote::quoteSingleIdentifier($columnDefinition->getColumnName())
+                );
+            } else {
+                // on columns other than string dont use COALESCE, use direct cast
+                // this will fail if the column is not null, but this is expected
+                $columnsSetSql[] = sprintf(
+                    'CAST(%s as %s) AS %s',
+                    SynapseQuote::quoteSingleIdentifier($columnDefinition->getColumnName()),
+                    $this->getColumnTypeSqlDefinition($columnDefinition),
+                    SynapseQuote::quoteSingleIdentifier($columnDefinition->getColumnName())
+                );
+            }
+        }
+
+        if ($useTimestamp) {
+            $columnsSetSql[] = sprintf('%s AS %s', SynapseQuote::quote($timestamp), ToStageImporterInterface::TIMESTAMP_COLUMN_NAME);
+        }
+
+        $distributionSql = $this->getSqlDistributionPart($destinationTableDefinition);
+        $indexSql = $this->getSqlIndexPart($destinationTableDefinition);
+
+        return sprintf(
+            'CREATE TABLE %s WITH (%s,%s) AS SELECT %s FROM %s.%s',
+            $destinationTable,
+            $distributionSql,
+            $indexSql,
             implode(',', $columnsSetSql),
             SynapseQuote::quoteSingleIdentifier($sourceTableDefinition->getSchemaName()),
             SynapseQuote::quoteSingleIdentifier($sourceTableDefinition->getTableName())


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/KBC-2207

Behavior of the the getCTASInsertAllIntoTargetTableCommand is bit different then getInsertAllIntoTargetTableCommand as the created table will have same columns as source and will not have any extra columns, but it's same behavior as load with PK has now. Also this is not possible to do in connection. 