### PR TITLE
KBC-2954 return FromTableInsertIntoAdapter and make it optional

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,11 +46,6 @@ parameters:
 			path: src/Backend/Synapse/ToFinalTable/SqlBuilder.php
 
 		-
-			message: "#^Parameter \\#3 \\$types of method Doctrine\\\\DBAL\\\\Connection\\:\\:executeQuery\\(\\) expects array\\<int\\|string, Doctrine\\\\DBAL\\\\Types\\\\Type\\|int\\|string\\|null\\>, array given\\.$#"
-			count: 1
-			path: src/Backend/Synapse/ToStage/FromTableCTASAdapter.php
-
-		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: src/Backend/Teradata/ToFinalTable/FullImporter.php
@@ -117,11 +112,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$sql of method Doctrine\\\\DBAL\\\\Connection\\:\\:exec\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Storage/ABS/SynapseExportAdapter.php
-
-		-
-			message: "#^Parameter \\#3 \\$types of method Doctrine\\\\DBAL\\\\Connection\\:\\:executeQuery\\(\\) expects array\\<int\\|string, Doctrine\\\\DBAL\\\\Types\\\\Type\\|int\\|string\\|null\\>, array given\\.$#"
 			count: 1
 			path: src/Storage/ABS/SynapseExportAdapter.php
 

--- a/src/Backend/Synapse/SynapseImportOptions.php
+++ b/src/Backend/Synapse/SynapseImportOptions.php
@@ -17,6 +17,9 @@ class SynapseImportOptions extends ImportOptions
     public const SAME_TABLES_REQUIRED = true;
     public const SAME_TABLES_NOT_REQUIRED = false;
 
+    public const TABLE_TO_TABLE_ADAPTER_INSERT_INTO = 'INSERT_INTO';
+    public const TABLE_TO_TABLE_ADAPTER_CTAS = 'CTAS';
+
     /** @var self::CREDENTIALS_* */
     private string $importCredentialsType;
 
@@ -26,11 +29,14 @@ class SynapseImportOptions extends ImportOptions
     /** @var self::SAME_TABLES_* */
     private bool $requireSameTables;
 
+    private string $tableToTableAdapter;
+
     /**
      * @param string[] $convertEmptyValuesToNull
      * @param self::CREDENTIALS_* $importCredentialsType
      * @param self::TABLE_TYPES_* $castValueTypes
      * @param self::SAME_TABLES_* $requireSameTables
+     * @param self::TABLE_TO_TABLE_ADAPTER_* $tableToTableAdapter
      */
     public function __construct(
         array $convertEmptyValuesToNull = [],
@@ -39,7 +45,8 @@ class SynapseImportOptions extends ImportOptions
         int $numberOfIgnoredLines = 0,
         string $importCredentialsType = self::CREDENTIALS_SAS,
         string $castValueTypes = self::TABLE_TYPES_PRESERVE,
-        bool $requireSameTables = self::SAME_TABLES_NOT_REQUIRED
+        bool $requireSameTables = self::SAME_TABLES_NOT_REQUIRED,
+        string $tableToTableAdapter = self::TABLE_TO_TABLE_ADAPTER_INSERT_INTO
     ) {
         parent::__construct(
             $convertEmptyValuesToNull,
@@ -50,6 +57,12 @@ class SynapseImportOptions extends ImportOptions
         $this->importCredentialsType = $importCredentialsType;
         $this->castValueTypes = $castValueTypes;
         $this->requireSameTables = $requireSameTables;
+        $this->tableToTableAdapter = $tableToTableAdapter;
+    }
+
+    public function getTableToTableAdapter(): string
+    {
+        return $this->tableToTableAdapter;
     }
 
     public function getImportCredentialsType(): string

--- a/src/Backend/Synapse/ToStage/FromTableInsertIntoAdapter.php
+++ b/src/Backend/Synapse/ToStage/FromTableInsertIntoAdapter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Db\ImportExport\Backend\Synapse\ToStage;
+
+use Doctrine\DBAL\Connection;
+use Keboola\Db\ImportExport\Backend\CopyAdapterInterface;
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\ImportOptionsInterface;
+use Keboola\Db\ImportExport\Storage;
+use Keboola\Db\ImportExport\Storage\Synapse\SelectSource;
+use Keboola\Db\ImportExport\Storage\Synapse\Table;
+use Keboola\TableBackendUtils\Escaping\SynapseQuote;
+use Keboola\TableBackendUtils\Table\SynapseTableDefinition;
+use Keboola\TableBackendUtils\Table\SynapseTableReflection;
+use Keboola\TableBackendUtils\Table\TableDefinitionInterface;
+
+class FromTableInsertIntoAdapter implements CopyAdapterInterface
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function runCopyCommand(
+        Storage\SourceInterface $source,
+        TableDefinitionInterface $destination,
+        ImportOptionsInterface $importOptions
+    ): int {
+        assert($source instanceof SelectSource || $source instanceof Table);
+        assert($destination instanceof SynapseTableDefinition);
+        assert($importOptions instanceof SynapseImportOptions);
+
+        $quotedColumns = array_map(function ($column) {
+            return SynapseQuote::quoteSingleIdentifier($column);
+        }, $source->getColumnsNames());
+
+        $sql = sprintf(
+            'INSERT INTO %s.%s (%s) %s',
+            SynapseQuote::quoteSingleIdentifier($destination->getSchemaName()),
+            SynapseQuote::quoteSingleIdentifier($destination->getTableName()),
+            implode(', ', $quotedColumns),
+            $source->getFromStatement()
+        );
+
+        if ($source instanceof SelectSource) {
+            $this->connection->executeQuery($sql, $source->getQueryBindings(), $source->getDataTypes());
+        } else {
+            $this->connection->executeStatement($sql);
+        }
+
+        $ref = new SynapseTableReflection(
+            $this->connection,
+            $destination->getSchemaName(),
+            $destination->getTableName()
+        );
+
+        return $ref->getRowsCount();
+    }
+}

--- a/src/Backend/Synapse/ToStage/ToStageImporter.php
+++ b/src/Backend/Synapse/ToStage/ToStageImporter.php
@@ -77,11 +77,7 @@ final class ToStageImporter implements ToStageImporterInterface
                 $adapter = new FromABSCopyIntoAdapter($this->connection);
                 break;
             case $source instanceof Storage\SqlSourceInterface:
-                if ($importOptions->getTableToTableAdapter() === SynapseImportOptions::TABLE_TO_TABLE_ADAPTER_CTAS) {
-                    $adapter = new FromTableCTASAdapter($this->connection);
-                } else {
-                    $adapter = new FromTableInsertIntoAdapter($this->connection);
-                }
+                $adapter = $this->getAdapterForSqlSource($importOptions);
                 break;
             default:
                 throw new LogicException(
@@ -92,5 +88,22 @@ final class ToStageImporter implements ToStageImporterInterface
                 );
         }
         return $adapter;
+    }
+
+    private function getAdapterForSqlSource(SynapseImportOptions $importOptions): CopyAdapterInterface
+    {
+        switch ($importOptions->getTableToTableAdapter()) {
+            case SynapseImportOptions::TABLE_TO_TABLE_ADAPTER_CTAS:
+                return new FromTableCTASAdapter($this->connection);
+            case SynapseImportOptions::TABLE_TO_TABLE_ADAPTER_INSERT_INTO:
+                return new FromTableInsertIntoAdapter($this->connection);
+        }
+
+        throw new LogicException(
+            sprintf(
+                'No suitable table to table adapter "%s".',
+                $importOptions->getTableToTableAdapter()
+            )
+        );
     }
 }

--- a/src/Storage/Synapse/SelectSource.php
+++ b/src/Storage/Synapse/SelectSource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\Db\ImportExport\Storage\Synapse;
 
+use Doctrine\DBAL\Types\Type;
 use Keboola\Db\ImportExport\Storage\SourceInterface;
 use Keboola\Db\ImportExport\Storage\SqlSourceInterface;
 
@@ -14,7 +15,7 @@ class SelectSource implements SourceInterface, SqlSourceInterface
     /** @var array<mixed> */
     private array $queryBindings;
 
-    /** @var array<mixed> */
+    /** @var array<int|string, Type|int|string|null> */
     private array $dataTypes;
 
     /** @var string[] */
@@ -26,7 +27,7 @@ class SelectSource implements SourceInterface, SqlSourceInterface
     /**
      * @param string[] $columnsNames
      * @param string[]|null $primaryKeysNames
-     * @param array<mixed> $dataTypes
+     * @param array<int|string, Type|int|string|null> $dataTypes
      * @param array<mixed>|null $queryBindings
      */
     public function __construct(
@@ -49,7 +50,7 @@ class SelectSource implements SourceInterface, SqlSourceInterface
         return $this->columnsNames;
     }
 
-    /** @return array<mixed> */
+    /** @return array<int|string, Type|int|string|null> */
     public function getDataTypes(): array
     {
         return $this->dataTypes;

--- a/tests/functional/Synapse/FullImportWithTypesTest.php
+++ b/tests/functional/Synapse/FullImportWithTypesTest.php
@@ -140,7 +140,7 @@ class FullImportWithTypesTest extends SynapseBaseTestCase
         ];
 
         // copy from table
-        yield ' copy from table' => [
+        yield ' copy from table ctas' => [
             new Storage\Synapse\Table(
                 $this->getSourceSchemaName(),
                 'types',
@@ -158,7 +158,35 @@ class FullImportWithTypesTest extends SynapseBaseTestCase
             $this->getSynapseImportOptions(
                 ImportOptions::SKIP_FIRST_LINE,
                 SynapseImportOptions::TABLE_TYPES_CAST,
-                SynapseImportOptions::SAME_TABLES_REQUIRED
+                SynapseImportOptions::SAME_TABLES_REQUIRED,
+                SynapseImportOptions::TABLE_TO_TABLE_ADAPTER_CTAS
+            ),
+            [['a', '10.5', '1.4', '1']],
+            1,
+            [self::TABLE_TYPES],
+        ];
+
+        // copy from table
+        yield ' copy from table insert into' => [
+            new Storage\Synapse\Table(
+                $this->getSourceSchemaName(),
+                'types',
+                [
+                    'charCol',
+                    'numCol',
+                    'floatCol',
+                    'boolCol',
+                ]
+            ),
+            [
+                $this->getDestinationSchemaName(),
+                'types',
+            ],
+            $this->getSynapseImportOptions(
+                ImportOptions::SKIP_FIRST_LINE,
+                SynapseImportOptions::TABLE_TYPES_CAST,
+                SynapseImportOptions::SAME_TABLES_REQUIRED,
+                SynapseImportOptions::TABLE_TO_TABLE_ADAPTER_INSERT_INTO
             ),
             [['a', '10.5', '1.4', '1']],
             1,

--- a/tests/functional/Synapse/OtherImports/StageImportTest.php
+++ b/tests/functional/Synapse/OtherImports/StageImportTest.php
@@ -318,7 +318,8 @@ class StageImportTest extends SynapseBaseTestCase
             $this->getSynapseImportOptions(
                 ImportOptions::SKIP_FIRST_LINE,
                 null,
-                SynapseImportOptions::SAME_TABLES_REQUIRED
+                SynapseImportOptions::SAME_TABLES_REQUIRED,
+                SynapseImportOptions::TABLE_TO_TABLE_ADAPTER_CTAS
             )
         );
     }

--- a/tests/functional/Synapse/SynapseBaseTestCase.php
+++ b/tests/functional/Synapse/SynapseBaseTestCase.php
@@ -344,11 +344,13 @@ EOT
     /**
      * @param null|SynapseImportOptions::TABLE_TYPES_* $castValueTypes
      * @param null|SynapseImportOptions::SAME_TABLES_* $requireSameTables
+     * @param null|SynapseImportOptions::TABLE_TO_TABLE_ADAPTER_* $tableToTableAdapter
      */
     protected function getSynapseImportOptions(
         int $skipLines = ImportOptions::SKIP_FIRST_LINE,
         ?string $castValueTypes = null,
-        ?bool $requireSameTables = null
+        ?bool $requireSameTables = null,
+        ?string $tableToTableAdapter = null
     ): SynapseImportOptions {
         return new SynapseImportOptions(
             [],
@@ -358,7 +360,8 @@ EOT
             // @phpstan-ignore-next-line
             getenv('CREDENTIALS_IMPORT_TYPE'),
             $castValueTypes ?? SynapseImportOptions::TABLE_TYPES_PRESERVE,
-            $requireSameTables ?? SynapseImportOptions::SAME_TABLES_NOT_REQUIRED
+            $requireSameTables ?? SynapseImportOptions::SAME_TABLES_NOT_REQUIRED,
+            $tableToTableAdapter ?? SynapseImportOptions::TABLE_TO_TABLE_ADAPTER_INSERT_INTO
         );
     }
 

--- a/tests/unit/Backend/Synapse/ToStage/FromTableInsertIntoAdapterTest.php
+++ b/tests/unit/Backend/Synapse/ToStage/FromTableInsertIntoAdapterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\Db\ImportExportUnit\Backend\Synapse\ToStage;
+
+use Keboola\Db\ImportExport\Backend\Synapse\SynapseImportOptions;
+use Keboola\Db\ImportExport\Backend\Synapse\ToStage\FromTableInsertIntoAdapter;
+use Keboola\Db\ImportExport\Storage;
+use Keboola\TableBackendUtils\Column\ColumnCollection;
+use Keboola\TableBackendUtils\Column\SynapseColumn;
+use Keboola\TableBackendUtils\Table\Synapse\TableDistributionDefinition;
+use Keboola\TableBackendUtils\Table\Synapse\TableIndexDefinition;
+use Keboola\TableBackendUtils\Table\SynapseTableDefinition;
+use Tests\Keboola\Db\ImportExportUnit\Backend\Synapse\MockConnectionTrait;
+use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;
+
+class FromTableInsertIntoAdapterTest extends BaseTestCase
+{
+    use MockConnectionTrait;
+
+    public function testGetCopyCommands(): void
+    {
+        $source = new Storage\Synapse\Table('test_schema', 'test_table', ['col1', 'col2']);
+
+        $conn = $this->mockConnection();
+        $conn->expects($this->once())->method('executeStatement')->with(
+        // phpcs:ignore
+            'INSERT INTO [test_schema].[stagingTable] ([col1], [col2]) SELECT [col1], [col2] FROM [test_schema].[test_table]'
+        );
+        $conn->expects($this->once())->method('fetchOne')
+            ->with('SELECT COUNT_BIG(*) AS [count] FROM [test_schema].[stagingTable]')
+            ->willReturn(10);
+
+        $destination = new SynapseTableDefinition(
+            'test_schema',
+            'stagingTable',
+            true,
+            new ColumnCollection([
+                SynapseColumn::createGenericColumn('col1'),
+                SynapseColumn::createGenericColumn('col2'),
+            ]),
+            [],
+            new TableDistributionDefinition(TableDistributionDefinition::TABLE_DISTRIBUTION_ROUND_ROBIN),
+            new TableIndexDefinition(TableIndexDefinition::TABLE_INDEX_TYPE_HEAP)
+        );
+        $options = new SynapseImportOptions([]);
+        $adapter = new FromTableInsertIntoAdapter($conn);
+        $count = $adapter->runCopyCommand(
+            $source,
+            $destination,
+            $options
+        );
+
+        $this->assertEquals(10, $count);
+    }
+
+    public function testGetCopyCommandsSelectSource(): void
+    {
+        $source = new Storage\Synapse\SelectSource(
+            'SELECT * FROM [test_schema].[test_table]',
+            ['val'],
+            [1],
+            ['col1','col2']
+        );
+
+        $conn = $this->mockConnection();
+        $conn->expects($this->once())->method('executeQuery')->with(
+        // phpcs:ignore
+            'INSERT INTO [test_schema].[stagingTable] ([col1], [col2]) SELECT * FROM [test_schema].[test_table]',
+            ['val'],
+            [1]
+        );
+        $conn->expects($this->once())->method('fetchOne')
+            ->with('SELECT COUNT_BIG(*) AS [count] FROM [test_schema].[stagingTable]')
+            ->willReturn(10);
+
+        $destination = new SynapseTableDefinition(
+            'test_schema',
+            'stagingTable',
+            true,
+            new ColumnCollection([
+                SynapseColumn::createGenericColumn('col1'),
+                SynapseColumn::createGenericColumn('col2'),
+            ]),
+            [],
+            new TableDistributionDefinition(TableDistributionDefinition::TABLE_DISTRIBUTION_ROUND_ROBIN),
+            new TableIndexDefinition(TableIndexDefinition::TABLE_INDEX_TYPE_HEAP)
+        );
+        $options = new SynapseImportOptions([]);
+        $adapter = new FromTableInsertIntoAdapter($conn);
+        $count = $adapter->runCopyCommand(
+            $source,
+            $destination,
+            $options
+        );
+
+        $this->assertEquals(10, $count);
+    }
+}


### PR DESCRIPTION
[KBC-2954](https://keboola.atlassian.net/browse/KBC-2594)
Rollbacknul sem původní INSERT INTO adapter pro Synapse, ten CTAS neumí column rename, který sa používá při IM a implementovat to by byla docela pruda, zvlášť když je to potřeba jen pro inkrementální load do WS, který sa spíš nepoužívá.