### PR TITLE
Dedup table follows table definition of target table

### DIFF
--- a/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
+++ b/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
@@ -79,31 +79,12 @@ final class StageTableDefinitionFactory
         SnowflakeTableDefinition $destination,
         array $pkNames
     ): SnowflakeTableDefinition {
-        // ensure that PK on dedup table are not null
-        $dedupTableColumns = [];
-        /** @var SnowflakeColumn $definition */
-        foreach ($destination->getColumnsDefinitions() as $definition) {
-            if (in_array($definition->getColumnName(), $pkNames)) {
-                $dedupTableColumns[] = new SnowflakeColumn(
-                    $definition->getColumnName(),
-                    new Snowflake(
-                        $definition->getColumnDefinition()->getType(),
-                        [
-                            'length' => $definition->getColumnDefinition()->getLength(),
-                            'nullable' => false,
-                        ]
-                    )
-                );
-            } else {
-                $dedupTableColumns[] = $definition;
-            }
-        }
 
         return new SnowflakeTableDefinition(
             $destination->getSchemaName(),
             BackendHelper::generateTempDedupTableName(),
             true,
-            new ColumnCollection($dedupTableColumns),
+            $destination->getColumnsDefinitions(),
             $pkNames
         );
     }

--- a/tests/functional/Snowflake/ToFinal/FullImportTest.php
+++ b/tests/functional/Snowflake/ToFinal/FullImportTest.php
@@ -36,7 +36,7 @@ class FullImportTest extends SnowflakeBaseTestCase
         $this->createSchema($this->getDestinationSchemaName());
     }
 
-    public function testLoadToTableFailOnNullConstraint(): void
+    public function testLoadToTableWithNullValuesShouldPass(): void
     {
         $this->initTable(self::TABLE_SINGLE_PK);
 
@@ -81,16 +81,14 @@ class FullImportTest extends SnowflakeBaseTestCase
         );
         $toFinalTableImporter = new FullImporter($this->connection);
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage(
-            'Load error: An exception occurred while executing a query: NULL result in a non-nullable column'
-        );
         $toFinalTableImporter->importToTable(
             $stagingTable,
             $destination,
             $options,
             $importState
         );
+
+        self::assertEquals(5, $destinationRef->getRowsCount());
     }
 
     public function testLoadToFinalTableWithoutDedup(): void


### PR DESCRIPTION
caused error when data loaded to dedup table had nulls
![image](https://user-images.githubusercontent.com/13363655/179716840-753e2422-227e-4f6e-979e-104b573a4c6e.png)
