### PR TITLE
KBC-2793 Staging table full of varchars

### DIFF
--- a/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
+++ b/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
@@ -85,7 +85,7 @@ final class StageTableDefinitionFactory
         return new SnowflakeColumn(
             $columnName,
             new Snowflake(
-                Snowflake::TYPE_STRING,
+                Snowflake::TYPE_VARCHAR,
                 [
                     'length' => (string) Snowflake::MAX_VARCHAR_LENGTH,
                     'nullable' => true, // set all columns to be nullable

--- a/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
+++ b/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
@@ -58,6 +58,29 @@ final class StageTableDefinitionFactory
         );
     }
 
+    /**
+     * @param string[] $sourceColumnsNames
+     */
+    public static function createVarcharStagingTableDefinition(
+        array $sourceColumnsNames
+    ): SnowflakeTableDefinition {
+        /** @var SnowflakeTableDefinition $destination */
+        $newDefinitions = [];
+        // create staging table for source columns in order
+        foreach ($sourceColumnsNames as $columnName) {
+            /** @var SnowflakeColumn $definition */
+            $newDefinitions[] = self::createNvarcharColumn($columnName);
+        }
+
+        return new SnowflakeTableDefinition(
+            $destination->getSchemaName(),
+            BackendHelper::generateStagingTableName(),
+            true,
+            new ColumnCollection($newDefinitions),
+            $destination->getPrimaryKeysNames()
+        );
+    }
+
     private static function createNvarcharColumn(string $columnName): SnowflakeColumn
     {
         return new SnowflakeColumn(

--- a/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
+++ b/src/Backend/Snowflake/ToStage/StageTableDefinitionFactory.php
@@ -62,22 +62,21 @@ final class StageTableDefinitionFactory
      * @param string[] $sourceColumnsNames
      */
     public static function createVarcharStagingTableDefinition(
+        string $schemaName,
         array $sourceColumnsNames
     ): SnowflakeTableDefinition {
-        /** @var SnowflakeTableDefinition $destination */
         $newDefinitions = [];
         // create staging table for source columns in order
         foreach ($sourceColumnsNames as $columnName) {
-            /** @var SnowflakeColumn $definition */
             $newDefinitions[] = self::createNvarcharColumn($columnName);
         }
 
         return new SnowflakeTableDefinition(
-            $destination->getSchemaName(),
+            $schemaName,
             BackendHelper::generateStagingTableName(),
             true,
             new ColumnCollection($newDefinitions),
-            $destination->getPrimaryKeysNames()
+            []
         );
     }
 
@@ -102,7 +101,6 @@ final class StageTableDefinitionFactory
         SnowflakeTableDefinition $destination,
         array $pkNames
     ): SnowflakeTableDefinition {
-
         return new SnowflakeTableDefinition(
             $destination->getSchemaName(),
             BackendHelper::generateTempDedupTableName(),

--- a/tests/unit/Backend/Snowflake/ToStage/StageTableDefinitionFactoryTest.php
+++ b/tests/unit/Backend/Snowflake/ToStage/StageTableDefinitionFactoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\Db\ImportExportUnit\Backend\Snowflake\ToStage;
+
+use Keboola\Datatype\Definition\Snowflake;
+use Keboola\Db\ImportExport\Backend\Snowflake\ToStage\StageTableDefinitionFactory;
+use Keboola\TableBackendUtils\Column\ColumnCollection;
+
+use Keboola\TableBackendUtils\Column\Snowflake\SnowflakeColumn;
+use Keboola\TableBackendUtils\Table\Snowflake\SnowflakeTableDefinition;
+use Tests\Keboola\Db\ImportExportUnit\BaseTestCase;
+
+class StageTableDefinitionFactoryTest extends BaseTestCase
+{
+    public function testCreateStagingTableDefinitionWithTypes(): void
+    {
+        $definition = new SnowflakeTableDefinition(
+            'schema',
+            'table',
+            false,
+            new ColumnCollection([
+                new SnowflakeColumn('name', new Snowflake(Snowflake::TYPE_DATE)),
+                SnowflakeColumn::createGenericColumn('id'),
+            ]),
+            []
+        );
+        $stageDefinition = StageTableDefinitionFactory::createStagingTableDefinition(
+            $definition,
+            ['id', 'name', 'notInDef']
+        );
+
+        self::assertSame('schema', $stageDefinition->getSchemaName());
+        self::assertStringStartsWith('__temp_', $stageDefinition->getTableName());
+        self::assertTrue($stageDefinition->isTemporary());
+        // order same as source
+        self::assertSame(['id', 'name', 'notInDef'], $stageDefinition->getColumnsNames());
+        /** @var SnowflakeColumn[] $definitions */
+        $definitions = iterator_to_array($stageDefinition->getColumnsDefinitions());
+        // id is NVARCHAR
+        self::assertSame(Snowflake::TYPE_VARCHAR, $definitions[0]->getColumnDefinition()->getType());
+        // name is DATE
+        self::assertSame(Snowflake::TYPE_DATE, $definitions[1]->getColumnDefinition()->getType());
+        // notInDef has default NVARCHAR
+        self::assertSame(
+            Snowflake::TYPE_VARCHAR,
+            $definitions[2]->getColumnDefinition()->getType()
+        );
+    }
+
+    public function testCreateStagingTableDefinitionWithText(): void
+    {
+        $columns = ['id', 'name', 'number', 'notInDef'];
+        $stageDefinition = StageTableDefinitionFactory::createVarcharStagingTableDefinition(
+            'schema',
+            $columns
+        );
+
+        self::assertSame('schema', $stageDefinition->getSchemaName());
+        self::assertStringStartsWith('__temp_', $stageDefinition->getTableName());
+        self::assertTrue($stageDefinition->isTemporary());
+        // order same as source
+        self::assertSame($columns, $stageDefinition->getColumnsNames());
+        /** @var SnowflakeColumn[] $definitions */
+        $definitions = iterator_to_array($stageDefinition->getColumnsDefinitions());
+        foreach ($columns as $i => $columnName) {
+            self::assertSame(Snowflake::TYPE_VARCHAR, $definitions[$i]->getColumnDefinition()->getType());
+            self::assertSame($columnName, $definitions[$i]->getColumnName());
+        }
+    }
+}


### PR DESCRIPTION
Jira https://keboola.atlassian.net/browse/KBC-2793

prerequsity for https://github.com/keboola/connection/pull/3886

allows to create staging table definition using only varchars (ignoring native datatypes)