### PR TITLE
KBC-2886 split requireSameTables to requireSameTables and nullManipulation

### DIFF
--- a/src/Backend/Snowflake/SnowflakeImportOptions.php
+++ b/src/Backend/Snowflake/SnowflakeImportOptions.php
@@ -10,30 +10,45 @@ class SnowflakeImportOptions extends ImportOptions
 {
     public const SAME_TABLES_REQUIRED = true;
     public const SAME_TABLES_NOT_REQUIRED = false;
+    public const NULL_MANIPULATION_ENABLED = true;
+    public const NULL_MANIPULATION_SKIP = false;
 
     /** @var self::SAME_TABLES_* */
     private bool $requireSameTables;
 
+    /** @var self::NULL_MANIPULATION_* */
+    private bool $nullManipulation;
+
     /**
      * @param string[] $convertEmptyValuesToNull
      * @param self::SAME_TABLES_* $requireSameTables
+     * @param self::NULL_MANIPULATION_* $nullManipulation
      */
     public function __construct(
         array $convertEmptyValuesToNull = [],
         bool $isIncremental = false,
         bool $useTimestamp = false,
         int $numberOfIgnoredLines = 0,
-        bool $requireSameTables = self::SAME_TABLES_NOT_REQUIRED
+        bool $requireSameTables = self::SAME_TABLES_NOT_REQUIRED,
+        bool $nullManipulation = self::NULL_MANIPULATION_ENABLED
     ) {
-        parent::__construct($convertEmptyValuesToNull, $isIncremental, $useTimestamp, $numberOfIgnoredLines);
+        parent::__construct(
+            $convertEmptyValuesToNull,
+            $isIncremental,
+            $useTimestamp,
+            $numberOfIgnoredLines
+        );
         $this->requireSameTables = $requireSameTables;
+        $this->nullManipulation = $nullManipulation;
     }
 
-    /**
-     * @return self::SAME_TABLES_*
-     */
     public function isRequireSameTables(): bool
     {
-        return $this->requireSameTables;
+        return $this->requireSameTables === self::SAME_TABLES_REQUIRED;
+    }
+
+    public function isNullManipulationEnabled(): bool
+    {
+        return $this->nullManipulation === self::NULL_MANIPULATION_ENABLED;
     }
 }

--- a/src/Backend/Snowflake/ToFinalTable/SqlBuilder.php
+++ b/src/Backend/Snowflake/ToFinalTable/SqlBuilder.php
@@ -129,7 +129,7 @@ class SqlBuilder
     ): string {
         $pkWhereSql = array_map(function (string $col) use ($importOptions) {
             $str = '"dest".%s = COALESCE("src".%s, \'\')';
-            if ($importOptions->isRequireSameTables() === true) {
+            if (!$importOptions->isNullManipulationEnabled()) {
                 $str = '"dest".%s = "src".%s';
             }
             return sprintf(
@@ -182,7 +182,7 @@ class SqlBuilder
         /** @var SnowflakeColumn $columnDefinition */
         foreach ($sourceTableDefinition->getColumnsDefinitions() as $columnDefinition) {
             // output mapping same tables are required do not convert nulls to empty strings
-            if ($importOptions->isRequireSameTables() === true) {
+            if (!$importOptions->isNullManipulationEnabled()) {
                 $columnsSetSql[] = SnowflakeQuote::quoteSingleIdentifier($columnDefinition->getColumnName());
                 continue;
             }
@@ -255,7 +255,7 @@ class SqlBuilder
         $columnsSet = [];
 
         foreach ($stagingTableDefinition->getColumnsNames() as $columnName) {
-            if ($importOptions->isRequireSameTables() === true) {
+            if (!$importOptions->isNullManipulationEnabled()) {
                 $columnsSet[] = sprintf(
                     '%s = "src".%s',
                     SnowflakeQuote::quoteSingleIdentifier($columnName),
@@ -288,7 +288,7 @@ class SqlBuilder
         }
 
         // update only changed rows - mysql TIMESTAMP ON UPDATE behaviour simulation
-        if ($importOptions->isRequireSameTables() === true) {
+        if (!$importOptions->isNullManipulationEnabled()) {
             $columnsComparisonSql = array_map(
                 static function ($columnName) {
                     return sprintf(

--- a/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
+++ b/tests/functional/Snowflake/ToFinal/SqlBuilderTest.php
@@ -306,7 +306,8 @@ class SqlBuilderTest extends SnowflakeBaseTestCase
                 false,
                 false,
                 0,
-                SnowflakeImportOptions::SAME_TABLES_REQUIRED //<- same tables are required
+                SnowflakeImportOptions::SAME_TABLES_NOT_REQUIRED,
+                SnowflakeImportOptions::NULL_MANIPULATION_SKIP //<- skipp null manipulation
             ),
         );
 
@@ -477,7 +478,8 @@ EOT
                 false,
                 false,
                 0,
-                SnowflakeImportOptions::SAME_TABLES_REQUIRED //<- same tables are required
+                SnowflakeImportOptions::SAME_TABLES_NOT_REQUIRED,
+                SnowflakeImportOptions::NULL_MANIPULATION_SKIP //<- skipp null manipulation
             ),
             '2020-01-01 00:00:00'
         );
@@ -833,7 +835,8 @@ EOT
                 false,
                 false,
                 0,
-                SnowflakeImportOptions::SAME_TABLES_REQUIRED //<- same tables are required
+                SnowflakeImportOptions::SAME_TABLES_NOT_REQUIRED,
+                SnowflakeImportOptions::NULL_MANIPULATION_SKIP //<- skipp null manipulation
             ),
             '2020-01-01 00:00:00'
         );


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/KBC-2886

- require same tables was used to change behavior of queries, now this has own option nullManipulation
- this could be considered as BC, but it changes only internal behavior used in connection

---
- rebased on kbc-2903 since it's fixing new phpstan version issues