### PR TITLE
Update php-temp lib to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "keboola/php-csv-db-import": "^5.0",
         "keboola/php-datatypes": "^6.0",
         "keboola/php-file-storage-utils": ">=0.2",
-        "keboola/php-temp": "^1.0",
+        "keboola/php-temp": "^2.0",
         "keboola/table-backend-utils": "^1",
         "microsoft/azure-storage-blob": "^1.4",
         "symfony/process": "^4.4|^5.0|^6.0"

--- a/src/Backend/Teradata/ToStage/FromS3TPTAdapter.php
+++ b/src/Backend/Teradata/ToStage/FromS3TPTAdapter.php
@@ -174,7 +174,6 @@ class FromS3TPTAdapter implements CopyAdapterInterface
         TeradataImportOptions $importOptions
     ): array {
         $temp = new Temp();
-        $temp->initRunFolder();
         $folder = $temp->getTmpFolder();
         $target = sprintf(
             '%s.%s',

--- a/src/Backend/Teradata/ToStage/FromS3TPTAdapter.php
+++ b/src/Backend/Teradata/ToStage/FromS3TPTAdapter.php
@@ -141,6 +141,9 @@ class FromS3TPTAdapter implements CopyAdapterInterface
             );
         }
 
+        // delete temp files
+        $temp->remove();
+
         $ref = new TeradataTableReflection(
             $this->connection,
             $destination->getSchemaName(),
@@ -153,7 +156,10 @@ class FromS3TPTAdapter implements CopyAdapterInterface
     private function getLogData(Temp $temp): string
     {
         if (file_exists($temp->getTmpFolder() . '/import-1.out')) {
-            return file_get_contents($temp->getTmpFolder() . '/import-1.out') ?: 'unable to get error';
+            $data = file_get_contents($temp->getTmpFolder() . '/import-1.out') ?: 'unable to get error';
+            // delete temp files
+            $temp->remove();
+            return $data;
         }
 
         return 'unable to get error';

--- a/src/Storage/S3/TeradataExportTPTAdapter.php
+++ b/src/Storage/S3/TeradataExportTPTAdapter.php
@@ -101,7 +101,6 @@ class TeradataExportTPTAdapter implements BackendExportAdapterInterface
         TeradataExportOptions $exportOptions
     ): array {
         $temp = new Temp();
-        $temp->initRunFolder();
         $folder = $temp->getTmpFolder();
         $s3ConfigDir = $folder . '/.aws';
         touch($s3ConfigDir);

--- a/src/Storage/S3/TeradataExportTPTAdapter.php
+++ b/src/Storage/S3/TeradataExportTPTAdapter.php
@@ -79,6 +79,9 @@ class TeradataExportTPTAdapter implements BackendExportAdapterInterface
             );
         }
 
+        // delete temp files
+        $temp->remove();
+
         if ($exportOptions->generateManifest()) {
             (new Storage\S3\ManifestGenerator\S3SlicedManifestFromFolderGenerator($destination->getClient()))
                 ->generateAndSaveManifest($destination->getRelativePath());
@@ -195,7 +198,10 @@ EOD,
     private function getLogData(Temp $temp): string
     {
         if (file_exists($temp->getTmpFolder() . '/export-1.out')) {
-            return file_get_contents($temp->getTmpFolder() . '/export-1.out') ?: 'unable to get error';
+            $data = file_get_contents($temp->getTmpFolder() . '/export-1.out') ?: 'unable to get error';
+            // delete temp files
+            $temp->remove();
+            return $data;
         }
 
         return 'unable to get error';

--- a/tests/Common/StorageTrait.php
+++ b/tests/Common/StorageTrait.php
@@ -319,7 +319,6 @@ trait StorageTrait
         string $tmpName = 'tmp.csv'
     ): CsvFile {
         $tmp = new Temp();
-        $tmp->initRunFolder();
         $tmpFolder = $tmp->getTmpFolder();
         $finalFile = $tmpFolder . $tmpName;
         $tmpFiles = [];


### PR DESCRIPTION
Aby se dala libka pouzit v nove [komponente](https://github.com/keboola/php-component/blob/master/composer.json#L41), je potreba upgradnout libku `keboola/php-temp` na verzi 2.0.