### PR TITLE
Colums destination instead of source

### DIFF
--- a/src/Backend/Bigquery/ToStage/FromTableInsertIntoAdapter.php
+++ b/src/Backend/Bigquery/ToStage/FromTableInsertIntoAdapter.php
@@ -41,7 +41,7 @@ class FromTableInsertIntoAdapter implements CopyAdapterInterface
 
         $quotedColumns = array_map(static function ($column) {
             return BigqueryQuote::quoteSingleIdentifier($column);
-        }, $source->getColumnsNames());
+        }, $destination->getColumnsNames());
 
         if ($source instanceof Table && $importOptions->usingUserDefinedTypes()) {
             Assert::assertSameColumns(


### PR DESCRIPTION
Jira: KBC-XXX

Before asking for review make sure that:

- [x] In the case of **modified import queries**, I checked that the [CustomQuery component](https://github.com/keboola/app-custom-query-manager) is updated.

---
Zacal som pisat import z WS v driveru a padali mi testy na tom ze cielova tabulka nema dany stlpce (v testoch sa schvalne berie zo stlpca col2 a destination tabulka ma stlpec col4) ked som sa pozerel na TD tak je to tam rovnako ako v tomto PR
https://github.com/keboola/php-db-import-export/blob/master/src/Backend/Teradata/ToStage/FromTableInsertIntoAdapter.php#L37-L39